### PR TITLE
모집글 참여 신청 취소 기능 구현, RecruitService, ParticipantService 테스트 코드 추가, 리팩터링

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/participant/controller/ParticipantController.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/controller/ParticipantController.java
@@ -1,9 +1,9 @@
 package com.anonymous.usports.domain.participant.controller;
 
 import com.anonymous.usports.domain.member.dto.MemberDto;
-import com.anonymous.usports.domain.participant.dto.ParticipantDto;
 import com.anonymous.usports.domain.participant.dto.ParticipantListDto;
 import com.anonymous.usports.domain.participant.dto.ParticipantManage;
+import com.anonymous.usports.domain.participant.dto.ParticipateCancel;
 import com.anonymous.usports.domain.participant.dto.ParticipateResponse;
 import com.anonymous.usports.domain.participant.service.ParticipantService;
 import io.swagger.annotations.ApiOperation;
@@ -14,6 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -54,8 +55,20 @@ public class ParticipantController {
 
     ParticipantManage.Response result =
         participantService.manageJoinRecruit(request, recruitId,
-        loginMember.getMemberId());
+            loginMember.getMemberId());
 
     return ResponseEntity.ok(result);
   }
+
+
+  @ApiOperation("운동 모집 신청 취소")
+  @PutMapping("/recruit/{recruitId}/cancel")
+  public ResponseEntity<?> cancelJoinRecruit(@PathVariable Long recruitId,
+      @AuthenticationPrincipal MemberDto loginMember) {
+    ParticipateCancel result =
+        participantService.cancelJoinRecruit(recruitId, loginMember.getMemberId());
+
+    return ResponseEntity.ok(result);
+  }
+
 }

--- a/src/main/java/com/anonymous/usports/domain/participant/dto/ParticipantListDto.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/dto/ParticipantListDto.java
@@ -8,12 +8,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 import org.springframework.data.domain.Page;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@ToString
 @Builder
 public class ParticipantListDto {
 

--- a/src/main/java/com/anonymous/usports/domain/participant/dto/ParticipateCancel.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/dto/ParticipateCancel.java
@@ -1,0 +1,19 @@
+package com.anonymous.usports.domain.participant.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ParticipateCancel {
+  private Long recruitId;
+  private Long memberId;
+  private String message;
+}

--- a/src/main/java/com/anonymous/usports/domain/participant/entity/ParticipantEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/entity/ParticipantEntity.java
@@ -4,6 +4,7 @@ import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.global.type.ParticipantStatus;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
@@ -29,7 +30,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@EqualsAndHashCode
 @EntityListeners(AuditingEntityListener.class)
 @Entity(name = "participant")
 public class ParticipantEntity {
@@ -79,5 +79,22 @@ public class ParticipantEntity {
 
   public void evaluation() {
     this.evaluationAt = LocalDateTime.now();
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || getClass() != object.getClass()) {
+      return false;
+    }
+    ParticipantEntity that = (ParticipantEntity) object;
+    return Objects.equals(participantId, that.participantId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(participantId);
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/participant/entity/ParticipantEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/entity/ParticipantEntity.java
@@ -17,6 +17,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -28,6 +29,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@EqualsAndHashCode
 @EntityListeners(AuditingEntityListener.class)
 @Entity(name = "participant")
 public class ParticipantEntity {

--- a/src/main/java/com/anonymous/usports/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/repository/ParticipantRepository.java
@@ -14,4 +14,5 @@ import org.springframework.stereotype.Repository;
 public interface ParticipantRepository extends JpaRepository<ParticipantEntity, Long> {
   Optional<ParticipantEntity> findByMemberAndRecruitAndStatus(MemberEntity member, RecruitEntity recruit, ParticipantStatus status);
   Page<ParticipantEntity> findAllByRecruitAndStatusOrderByParticipantId(RecruitEntity recruit, ParticipantStatus status, Pageable pageable);
+  void deleteAllByRecruit(RecruitEntity recruit);
 }

--- a/src/main/java/com/anonymous/usports/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/service/ParticipantService.java
@@ -2,6 +2,7 @@ package com.anonymous.usports.domain.participant.service;
 
 import com.anonymous.usports.domain.participant.dto.ParticipantListDto;
 import com.anonymous.usports.domain.participant.dto.ParticipantManage;
+import com.anonymous.usports.domain.participant.dto.ParticipateCancel;
 import com.anonymous.usports.domain.participant.dto.ParticipateResponse;
 
 public interface ParticipantService {
@@ -20,5 +21,11 @@ public interface ParticipantService {
   /**
    * 참여 신청 수락 or 거절
    */
-  ParticipantManage.Response manageJoinRecruit(ParticipantManage.Request request, Long recruitId, Long loginMemberId);
+  ParticipantManage.Response manageJoinRecruit(ParticipantManage.Request request, Long recruitId,
+      Long loginMemberId);
+
+  /**
+   * 참여 신청 취소
+   */
+  ParticipateCancel cancelJoinRecruit(Long recruitId, Long memberId);
 }

--- a/src/main/java/com/anonymous/usports/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/service/ParticipantService.java
@@ -8,7 +8,7 @@ import com.anonymous.usports.domain.participant.dto.ParticipateResponse;
 public interface ParticipantService {
 
   /**
-   * Recruit에 대한 참여 신청자 리스트 조회
+   * Recruit에 대한 참여 신청 진행중인 리스트 조회
    */
   ParticipantListDto getParticipants(Long recruitId, int page, Long memberId);
 

--- a/src/main/java/com/anonymous/usports/domain/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/service/impl/ParticipantServiceImpl.java
@@ -43,7 +43,7 @@ public class ParticipantServiceImpl implements ParticipantService {
   @Transactional
   public ParticipantListDto getParticipants(Long recruitId, int page, Long loginMemberId) {
     RecruitEntity recruitEntity = recruitRepository.findById(recruitId)
-        .orElseThrow(() -> new MyException(ErrorCode.RECRUIT_NOT_FOUND));
+        .orElseThrow(() -> new RecruitException(ErrorCode.RECRUIT_NOT_FOUND));
 
     this.validateAuthority(recruitEntity, loginMemberId);
 
@@ -59,9 +59,9 @@ public class ParticipantServiceImpl implements ParticipantService {
   @Transactional
   public ParticipateResponse joinRecruit(Long memberId, Long recruitId) {
     MemberEntity memberEntity = memberRepository.findById(memberId)
-        .orElseThrow(() -> new MyException(ErrorCode.MEMBER_NOT_FOUND));
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
     RecruitEntity recruitEntity = recruitRepository.findById(recruitId)
-        .orElseThrow(() -> new MyException(ErrorCode.RECRUIT_NOT_FOUND));
+        .orElseThrow(() -> new RecruitException(ErrorCode.RECRUIT_NOT_FOUND));
 
     //신청 진행중
     Optional<ParticipantEntity> ingParticipant =
@@ -90,19 +90,19 @@ public class ParticipantServiceImpl implements ParticipantService {
   public Response manageJoinRecruit(ParticipantManage.Request request, Long recruitId,
       Long loginMemberId) {
     MemberEntity applicant = memberRepository.findById(request.getApplicantId())
-        .orElseThrow(() -> new MyException(ErrorCode.APPLICANT_MEMBER_NOT_FOUND));
+        .orElseThrow(() -> new MemberException(ErrorCode.APPLICANT_MEMBER_NOT_FOUND));
     RecruitEntity recruitEntity = recruitRepository.findById(recruitId)
-        .orElseThrow(() -> new MyException(ErrorCode.RECRUIT_NOT_FOUND));
+        .orElseThrow(() -> new RecruitException(ErrorCode.RECRUIT_NOT_FOUND));
 
     this.validateAuthority(recruitEntity, loginMemberId);
     if (recruitEntity.getRecruitStatus() == RecruitStatus.END) {
-      throw new MyException(ErrorCode.RECRUIT_ALREADY_END);
+      throw new RecruitException(ErrorCode.RECRUIT_ALREADY_END);
     }
 
     ParticipantEntity participantEntity =
         participantRepository.findByMemberAndRecruitAndStatus(applicant, recruitEntity,
                 ParticipantStatus.ING)
-            .orElseThrow(() -> new MyException(ErrorCode.PARTICIPANT_NOT_FOUND));
+            .orElseThrow(() -> new ParticipantException(ErrorCode.PARTICIPANT_NOT_FOUND));
 
     //거절
     if (!request.isAccept()) {

--- a/src/main/java/com/anonymous/usports/domain/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/service/impl/ParticipantServiceImpl.java
@@ -117,11 +117,17 @@ public class ParticipantServiceImpl implements ParticipantService {
     participantRepository.save(participantEntity);
 
     recruitEntity.participantAdded();//Recruit의 currentCount + 1
+    int current = recruitEntity.getCurrentCount();
+    int total = recruitEntity.getRecruitCount();
 
     //수락 후 마감됨
-    if (recruitEntity.getCurrentCount() == recruitEntity.getRecruitCount()) {
+    if (current == total) {
       recruitEntity.statusToEnd();
+    }else if(0.7 <= (double)current / total){
+      //수락 후 ALMOST_FINISHED로 수정
+      recruitEntity.statusToAlmostFinished();
     }
+
     recruitRepository.save(recruitEntity);
 
     return new ParticipantManage.Response(recruitId, applicant.getMemberId(), true);

--- a/src/main/java/com/anonymous/usports/domain/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/service/impl/ParticipantServiceImpl.java
@@ -117,16 +117,6 @@ public class ParticipantServiceImpl implements ParticipantService {
     participantRepository.save(participantEntity);
 
     recruitEntity.participantAdded();//Recruit의 currentCount + 1
-    int current = recruitEntity.getCurrentCount();
-    int total = recruitEntity.getRecruitCount();
-
-    //수락 후 마감됨
-    if (current == total) {
-      recruitEntity.statusToEnd();
-    }else if(0.7 <= (double)current / total){
-      //수락 후 ALMOST_FINISHED로 수정
-      recruitEntity.statusToAlmostFinished();
-    }
 
     recruitRepository.save(recruitEntity);
 

--- a/src/main/java/com/anonymous/usports/domain/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/service/impl/ParticipantServiceImpl.java
@@ -15,7 +15,10 @@ import com.anonymous.usports.domain.recruit.repository.RecruitRepository;
 import com.anonymous.usports.global.constant.NumberConstant;
 import com.anonymous.usports.global.constant.ResponseConstant;
 import com.anonymous.usports.global.exception.ErrorCode;
+import com.anonymous.usports.global.exception.MemberException;
 import com.anonymous.usports.global.exception.MyException;
+import com.anonymous.usports.global.exception.ParticipantException;
+import com.anonymous.usports.global.exception.RecruitException;
 import com.anonymous.usports.global.type.ParticipantStatus;
 import com.anonymous.usports.global.type.RecruitStatus;
 import java.util.Objects;
@@ -131,28 +134,28 @@ public class ParticipantServiceImpl implements ParticipantService {
   }
 
   @Override
-  public ParticipateCancel cancelJoinRecruit(Long recruitId, Long memberId) {
-    MemberEntity applicant = memberRepository.findById(recruitId)
-        .orElseThrow(() -> new MyException(ErrorCode.APPLICANT_MEMBER_NOT_FOUND));
+  public ParticipateCancel cancelJoinRecruit(Long recruitId, Long loginMemberId) {
+    MemberEntity applicant = memberRepository.findById(loginMemberId)
+        .orElseThrow(() -> new MemberException(ErrorCode.APPLICANT_MEMBER_NOT_FOUND));
     RecruitEntity recruitEntity = recruitRepository.findById(recruitId)
-        .orElseThrow(() -> new MyException(ErrorCode.RECRUIT_NOT_FOUND));
+        .orElseThrow(() -> new RecruitException(ErrorCode.RECRUIT_NOT_FOUND));
 
     //ING 상태의 참여 신청 찾기
     Optional<ParticipantEntity> ing = participantRepository.findByMemberAndRecruitAndStatus(
         applicant, recruitEntity, ParticipantStatus.ING);
     if (ing.isPresent()) {
       participantRepository.delete(ing.get());
-      return new ParticipateCancel(recruitId, memberId, ResponseConstant.CANCEL_JOIN_RECRUIT);
+      return new ParticipateCancel(recruitId, loginMemberId, ResponseConstant.CANCEL_JOIN_RECRUIT);
     }
     //ACCEPTED 상태의 참여 신청 찾기
     Optional<ParticipantEntity> accepted = participantRepository.findByMemberAndRecruitAndStatus(
         applicant, recruitEntity, ParticipantStatus.ACCEPTED);
     if (accepted.isPresent()) {
       participantRepository.delete(accepted.get());
-      return new ParticipateCancel(recruitId, memberId, ResponseConstant.CANCEL_JOIN_RECRUIT);
+      return new ParticipateCancel(recruitId, loginMemberId, ResponseConstant.CANCEL_JOIN_RECRUIT);
     }
 
     //아무것도 찾지 못한 경우
-    throw new MyException(ErrorCode.PARTICIPANT_NOT_FOUND);
+    throw new ParticipantException(ErrorCode.PARTICIPANT_NOT_FOUND);
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/service/impl/ParticipantServiceImpl.java
@@ -158,6 +158,7 @@ public class ParticipantServiceImpl implements ParticipantService {
         applicant, recruitEntity, ParticipantStatus.ACCEPTED);
     if (accepted.isPresent()) {
       participantRepository.delete(accepted.get());
+      recruitEntity.participantCanceled();
       return new ParticipateCancel(recruitId, loginMemberId, ResponseConstant.CANCEL_JOIN_RECRUIT);
     }
 

--- a/src/main/java/com/anonymous/usports/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/controller/RecruitController.java
@@ -73,7 +73,7 @@ public class RecruitController {
   @DeleteMapping("/recruit/{recruitId}")
   public ResponseEntity<?> deleteRecruit(@PathVariable Long recruitId,
       @AuthenticationPrincipal MemberDto loginMember) {
-    //TODO : 게시글 삭제 전에 Participant 모두 삭제? 멘토님께 여쭤보기.
+
     RecruitDto result = recruitService.deleteRecruit(recruitId, loginMember.getMemberId());
     return ResponseEntity.ok(new RecruitDeleteResponse(result));
   }

--- a/src/main/java/com/anonymous/usports/domain/recruit/entity/RecruitEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/entity/RecruitEntity.java
@@ -21,9 +21,11 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -33,6 +35,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@ToString
+@EqualsAndHashCode
 @EntityListeners(AuditingEntityListener.class)
 @Entity(name = "recruit")
 public class RecruitEntity {

--- a/src/main/java/com/anonymous/usports/domain/recruit/entity/RecruitEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/entity/RecruitEntity.java
@@ -119,10 +119,20 @@ public class RecruitEntity {
 
   public void participantAdded(){
     this.currentCount = this.currentCount + 1;
+    if(this.currentCount == this.recruitCount){
+      this.recruitStatus = RecruitStatus.END;
+    }else if((double)this.currentCount / this.recruitCount >= 0.7){
+      this.recruitStatus = RecruitStatus.ALMOST_FINISHED;
+    }
   }
+
   public void participantCanceled(){
-    if(this.currentCount > 0){
-      this.currentCount = this.currentCount - 1;
+    if(this.currentCount == 0){
+      return;
+    }
+    this.currentCount = this.currentCount - 1;
+    if(this.recruitStatus == RecruitStatus.ALMOST_FINISHED && (double)this.currentCount / this.recruitCount <= 0.7){
+      this.recruitStatus = RecruitStatus.RECRUITING;
     }
   }
 

--- a/src/main/java/com/anonymous/usports/domain/recruit/entity/RecruitEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/entity/RecruitEntity.java
@@ -120,6 +120,11 @@ public class RecruitEntity {
   public void participantAdded(){
     this.currentCount = this.currentCount + 1;
   }
+  public void participantCanceled(){
+    if(this.currentCount > 0){
+      this.currentCount = this.currentCount - 1;
+    }
+  }
 
   public void statusToEnd(){
     this.recruitStatus = RecruitStatus.END;

--- a/src/main/java/com/anonymous/usports/domain/recruit/entity/RecruitEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/entity/RecruitEntity.java
@@ -7,6 +7,7 @@ import com.anonymous.usports.global.type.Gender;
 import com.anonymous.usports.global.type.RecruitStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 
@@ -35,8 +36,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@ToString
-@EqualsAndHashCode
 @EntityListeners(AuditingEntityListener.class)
 @Entity(name = "recruit")
 public class RecruitEntity {
@@ -135,4 +134,20 @@ public class RecruitEntity {
   }
 
 
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || getClass() != object.getClass()) {
+      return false;
+    }
+    RecruitEntity that = (RecruitEntity) object;
+    return Objects.equals(recruitId, that.recruitId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(recruitId);
+  }
 }

--- a/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
@@ -2,6 +2,7 @@ package com.anonymous.usports.domain.recruit.service.impl;
 
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.domain.participant.repository.ParticipantRepository;
 import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister.Request;
@@ -32,6 +33,7 @@ public class RecruitServiceImpl implements RecruitService {
   private final MemberRepository memberRepository;
   private final SportsRepository sportsRepository;
   private final RecruitRepository recruitRepository;
+  private final ParticipantRepository participantRepository;
 
   @Override
   @Transactional
@@ -84,6 +86,8 @@ public class RecruitServiceImpl implements RecruitService {
     MemberEntity memberEntity = recruitEntity.getMember(); //작성자
 
     this.validateAuthority(memberEntity, memberId);
+
+    participantRepository.deleteAllByRecruit(recruitEntity);
 
     recruitRepository.delete(recruitEntity);
 

--- a/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
@@ -44,7 +44,6 @@ public class RecruitServiceImpl implements RecruitService {
 
     RecruitEntity saved =
         recruitRepository.save(Request.toEntity(request, memberEntity, sportsEntity));
-    System.out.println(saved);
 
     return RecruitDto.fromEntity(saved);
   }

--- a/src/main/java/com/anonymous/usports/global/constant/ResponseConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/ResponseConstant.java
@@ -14,6 +14,8 @@ public class ResponseConstant {
   public static final String END_RECRUIT_COMPLETE = "모집 마감이 완료되었습니다.";
   public static final String END_RECRUIT_CANCELED = "모집 마감이 취소되고, 다시 등록되었습니다.";
   public static final String END_RECRUIT_CANCEL_REFUSED = "인원 수가 가득 차서 마감을 취소할 수 없습니다.";
+  public static final String CANCEL_JOIN_RECRUIT = "모집 신청이 취소되었습니다.";
+
 
   // 맴버 관련
   public static final String MEMBER_DELETE_SUCCESS = "회원 탈퇴를 성공적으로 했습니다";

--- a/src/main/java/com/anonymous/usports/global/exception/MyExceptionHandler.java
+++ b/src/main/java/com/anonymous/usports/global/exception/MyExceptionHandler.java
@@ -33,4 +33,18 @@ public class MyExceptionHandler {
     return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatusCode());
   }
 
+  @ExceptionHandler(RecruitException.class)
+  public ResponseEntity<ErrorResponse> handleRecordException(RecruitException e) {
+    ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
+    return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatusCode());
+  }
+
+  @ExceptionHandler(ParticipantException.class)
+  public ResponseEntity<ErrorResponse> handleRecordException(ParticipantException e) {
+    ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
+    return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatusCode());
+  }
+
+
+
 }

--- a/src/main/java/com/anonymous/usports/global/exception/ParticipantException.java
+++ b/src/main/java/com/anonymous/usports/global/exception/ParticipantException.java
@@ -1,0 +1,23 @@
+package com.anonymous.usports.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class ParticipantException extends RuntimeException{
+  private ErrorCode errorCode;
+  private String errorMessage;
+
+  public ParticipantException(ErrorCode errorCode) {
+    this.errorCode = errorCode;
+    this.errorMessage = errorCode.getDescription();
+  }
+
+}

--- a/src/main/java/com/anonymous/usports/global/exception/RecruitException.java
+++ b/src/main/java/com/anonymous/usports/global/exception/RecruitException.java
@@ -1,0 +1,23 @@
+package com.anonymous.usports.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class RecruitException extends RuntimeException{
+  private ErrorCode errorCode;
+  private String errorMessage;
+
+  public RecruitException(ErrorCode errorCode) {
+    this.errorCode = errorCode;
+    this.errorMessage = errorCode.getDescription();
+  }
+
+}

--- a/src/main/java/com/anonymous/usports/global/exception/SportsException.java
+++ b/src/main/java/com/anonymous/usports/global/exception/SportsException.java
@@ -1,0 +1,24 @@
+package com.anonymous.usports.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class SportsException extends RuntimeException {
+
+  private ErrorCode errorCode;
+  private String errorMessage;
+
+  public SportsException(ErrorCode errorCode) {
+    this.errorCode = errorCode;
+    this.errorMessage = errorCode.getDescription();
+  }
+
+}

--- a/src/test/java/com/anonymous/usports/domain/participant/service/ParticipantServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/participant/service/ParticipantServiceTest.java
@@ -3,7 +3,6 @@ package com.anonymous.usports.domain.participant.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -38,6 +37,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -47,8 +47,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 
+@Slf4j
 @ExtendWith(MockitoExtension.class)
 class ParticipantServiceTest {
 
@@ -94,6 +95,7 @@ class ParticipantServiceTest {
         .lnt("100")
         .cost(10000)
         .gender(Gender.MALE)
+        .currentCount(1)
         .recruitCount(10)
         .meetingDate(LocalDateTime.now())
         .recruitStatus(RecruitStatus.RECRUITING)
@@ -150,61 +152,106 @@ class ParticipantServiceTest {
         .build();
   }
 
+  @Nested
+  @DisplayName("신청중(ING)인 Participant 리스트 조회 (페이징)")
+  class GetParticipants {
 
-  @Test
-  @DisplayName("Participant 리스트 조회 (페이징)")
-  void getParticipants() {
-    //given
-    Long recruitId = recruit.getRecruitId();
-    int page = 1;
-    Long loginMemberId = member.getMemberId();
+    @Test
+    @DisplayName("성공")
+    void getParticipants() {
+      //given
+      MemberEntity recruitWriter = createMember(999L);
+      RecruitEntity recruit = createRecruit(10L, recruitWriter);
+      List<ParticipantEntity> participantList = new ArrayList<>();
 
-    List<ParticipantEntity> entityList = new ArrayList<>();
-    for (long i = 1; i <= 10; i++) {
-      entityList.add(ParticipantEntity.builder()
-          .participantId(i)
-          .member(MemberEntity.builder().memberId(i).build())
-          .recruit(recruit)
-          .registeredAt(LocalDateTime.now())
-          .build());
+      for (long i = 1; i <= 7; i++) {
+        MemberEntity memberEntity = createMember(i);
+        ParticipantEntity participant = createParticipant(i + 100, memberEntity, recruit);
+        participantList.add(participant);
+      }
+
+      int page = 2;
+
+      when(recruitRepository.findById(10L))
+          .thenReturn(Optional.of(recruit));
+      when(participantRepository
+          .findAllByRecruitAndStatusOrderByParticipantId(
+              recruit,
+              ParticipantStatus.ING,
+              PageRequest.of(page - 1, NumberConstant.PAGE_SIZE_DEFAULT))
+      ).thenReturn(new PageImpl<>(participantList));
+
+      //when
+      ParticipantListDto participants =
+          participantService.getParticipants(recruit.getRecruitId(), page,
+              recruitWriter.getMemberId());
+      log.info("participants : {}", participants);
+
+      //then
+      assertThat(participants.getCurrentPage()).isEqualTo(1);
+      assertThat(participants.getPageSize()).isEqualTo(7);
+      assertThat(participants.getTotalPages()).isEqualTo(1);
+      assertThat(participants.getTotalElements()).isEqualTo(7);
+
+      List<ParticipantDto> list = participants.getList();
+      for (int i = 0; i < list.size(); i++) {
+        ParticipantDto participantDto = list.get(i);
+        assertThat(participantDto.getRecruitId()).isEqualTo(recruit.getRecruitId());
+      }
     }
-    when(recruitRepository.findById(anyLong()))
-        .thenReturn(Optional.of(recruit));
-    when(participantRepository
-        .findAllByRecruitAndStatusOrderByParticipantId(any(RecruitEntity.class),
-            any(ParticipantStatus.class), any(Pageable.class)))
-        .thenReturn(new PageImpl<>(entityList));
 
-    //when
-    ParticipantListDto participants =
-        participantService.getParticipants(recruitId, page, loginMemberId);
+    @Test
+    @DisplayName("실패 - RECRUIT_NOT_FOUND")
+    void getParticipants_RECRUIT_NOT_FOUND() {
+      //given
+      MemberEntity recruitWriter = createMember(999L);
+      RecruitEntity recruit = createRecruit(10L, recruitWriter);
+      List<ParticipantEntity> participantList = new ArrayList<>();
 
-    //then
-    assertThat(participants.getCurrentPage()).isEqualTo(1);
-    assertThat(participants.getPageSize()).isEqualTo(NumberConstant.PAGE_SIZE_DEFAULT);
-    assertThat(participants.getTotalPages()).isEqualTo(1);
-    assertThat(participants.getTotalElements()).isEqualTo(10);
-    List<ParticipantDto> list = participants.getList();
-    for (int i = 0; i < list.size(); i++) {
-      assertThat(list.get(i).getRecruitId()).isEqualTo(recruitId);
+      for (long i = 1; i <= 7; i++) {
+        MemberEntity memberEntity = createMember(i);
+        ParticipantEntity participant = createParticipant(i + 100, memberEntity, recruit);
+        participantList.add(participant);
+      }
+
+      int page = 2;
+
+      when(recruitRepository.findById(9L))
+          .thenReturn(Optional.empty());
+      //when
+      //then
+      RecruitException exception =
+          catchThrowableOfType(() ->
+                  participantService
+                      .getParticipants(9L, page, recruitWriter.getMemberId()),
+              RecruitException.class);
+
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.RECRUIT_NOT_FOUND);
     }
 
   }
+
 
   @Nested
   @DisplayName("모집 글에 참여 신청 - joinRecruit")
   class JoinRecruit {
 
     @Test
-    @DisplayName("신청 성공")
+    @DisplayName("정상 - 신청 성공")
     void joinRecruit_JOIN_RECRUIT_COMPLETED() {
+      MemberEntity member = createMember(1L);
+      RecruitEntity recruit = createRecruit(10L, member);
+
       //given
-      when(memberRepository.findById(anyLong()))
+      when(memberRepository.findById(1L))
           .thenReturn(Optional.of(member));
-      when(recruitRepository.findById(anyLong()))
+      when(recruitRepository.findById(10L))
           .thenReturn(Optional.of(recruit));
-      when(participantRepository.findByMemberAndRecruitAndStatus(
-          any(MemberEntity.class), any(RecruitEntity.class), any(ParticipantStatus.class)))
+      when(participantRepository.findByMemberAndRecruitAndStatus(member, recruit,
+          ParticipantStatus.ING))
+          .thenReturn(Optional.empty());
+      when(participantRepository.findByMemberAndRecruitAndStatus(member, recruit,
+          ParticipantStatus.ACCEPTED))
           .thenReturn(Optional.empty());
 
       //when
@@ -221,23 +268,20 @@ class ParticipantServiceTest {
     }
 
     @Test
-    @DisplayName("신청 진행중인 상태")
+    @DisplayName("정상 - 신청 진행중인 상태")
     void joinRecruit_JOIN_RECRUIT_ING() {
-      ParticipantEntity participant = ParticipantEntity.builder()
-          .participantId(1L)
-          .member(member)
-          .recruit(recruit)
-          .status(ParticipantStatus.ING)
-          .registeredAt(LocalDateTime.now())
-          .build();
+      MemberEntity member = createMember(1L);
+      RecruitEntity recruit = createRecruit(10L, member);
+      ParticipantEntity participant = createParticipant(100L, member, recruit);
+      participant.setStatus(ParticipantStatus.ING);
 
       //given
-      when(memberRepository.findById(anyLong()))
+      when(memberRepository.findById(1L))
           .thenReturn(Optional.of(member));
-      when(recruitRepository.findById(anyLong()))
+      when(recruitRepository.findById(10L))
           .thenReturn(Optional.of(recruit));
-      when(participantRepository.findByMemberAndRecruitAndStatus(
-          any(MemberEntity.class), any(RecruitEntity.class), any(ParticipantStatus.class)))
+      when(participantRepository.findByMemberAndRecruitAndStatus(member, recruit,
+          ParticipantStatus.ING))
           .thenReturn(Optional.of(participant));
 
       //when
@@ -247,8 +291,7 @@ class ParticipantServiceTest {
       //then
       verify(participantRepository, never()).save(any(ParticipantEntity.class));
       verify(participantRepository, times(1))
-          .findByMemberAndRecruitAndStatus(
-              any(MemberEntity.class), any(RecruitEntity.class), any(ParticipantStatus.class));
+          .findByMemberAndRecruitAndStatus(member, recruit, ParticipantStatus.ING);
 
       assertThat(response.getRecruitId()).isEqualTo(recruit.getRecruitId());
       assertThat(response.getMemberId()).isEqualTo(member.getMemberId());
@@ -256,39 +299,81 @@ class ParticipantServiceTest {
     }
 
     @Test
-    @DisplayName("이미 신청이 수락 된 상태")
+    @DisplayName("정상 - 이미 신청이 수락 된 상태")
     void joinRecruit_JOIN_RECRUIT_ALREADY_CONFIRMED() {
-      ParticipantEntity participant = ParticipantEntity.builder()
-          .participantId(1L)
-          .member(member)
-          .recruit(recruit)
-          .status(ParticipantStatus.ACCEPTED)
-          .registeredAt(LocalDateTime.now().minusHours(1L))
-          .confirmedAt(LocalDateTime.now())
-          .build();
+      MemberEntity member = createMember(1L);
+      RecruitEntity recruit = createRecruit(10L, member);
+      ParticipantEntity participant = createParticipant(100L, member, recruit);
+      participant.setStatus(ParticipantStatus.ACCEPTED);
 
       //given
-      when(memberRepository.findById(anyLong()))
+      when(memberRepository.findById(1L))
           .thenReturn(Optional.of(member));
-      when(recruitRepository.findById(anyLong()))
+      when(recruitRepository.findById(10L))
           .thenReturn(Optional.of(recruit));
-      when(participantRepository.findByMemberAndRecruitAndStatus(
-          any(MemberEntity.class), any(RecruitEntity.class), any(ParticipantStatus.class)))
-          .thenReturn(Optional.empty())
+      when(participantRepository.findByMemberAndRecruitAndStatus(member, recruit,
+          ParticipantStatus.ING))
+          .thenReturn(Optional.empty());
+      when(participantRepository.findByMemberAndRecruitAndStatus(member, recruit,
+          ParticipantStatus.ACCEPTED))
           .thenReturn(Optional.of(participant));
+
       //when
       ParticipateResponse response =
           participantService.joinRecruit(member.getMemberId(), recruit.getRecruitId());
 
       //then
       verify(participantRepository, never()).save(any(ParticipantEntity.class));
-      verify(participantRepository, times(2))
-          .findByMemberAndRecruitAndStatus(
-              any(MemberEntity.class), any(RecruitEntity.class), any(ParticipantStatus.class));
+      verify(participantRepository, times(1))
+          .findByMemberAndRecruitAndStatus(member, recruit, ParticipantStatus.ING);
+      verify(participantRepository, times(1))
+          .findByMemberAndRecruitAndStatus(member, recruit, ParticipantStatus.ACCEPTED);
 
       assertThat(response.getRecruitId()).isEqualTo(recruit.getRecruitId());
       assertThat(response.getMemberId()).isEqualTo(member.getMemberId());
       assertThat(response.getMessage()).isEqualTo(ResponseConstant.JOIN_RECRUIT_ALREADY_ACCEPTED);
+    }
+
+    @Test
+    @DisplayName("실패 - MEMBER_NOT_FOUND")
+    void joinRecruit_MEMBER_NOT_FOUND() {
+      MemberEntity member = createMember(1L);
+      RecruitEntity recruit = createRecruit(10L, member);
+
+      //given
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      MemberException exception =
+          catchThrowableOfType(() ->
+              participantService.joinRecruit(
+                  member.getMemberId(), recruit.getRecruitId()), MemberException.class);
+
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패 - RECRUIT_NOT_FOUND")
+    void joinRecruit_RECRUIT_NOT_FOUND() {
+      MemberEntity member = createMember(1L);
+      RecruitEntity recruit = createRecruit(10L, member);
+
+      //given
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(recruitRepository.findById(10L))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      RecruitException exception =
+          catchThrowableOfType(() ->
+              participantService.joinRecruit(
+                  member.getMemberId(), recruit.getRecruitId()), RecruitException.class);
+
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.RECRUIT_NOT_FOUND);
     }
   }
 
@@ -297,103 +382,241 @@ class ParticipantServiceTest {
   class ManageJoinRecruit {
 
     @Test
-    @DisplayName("수락")
+    @DisplayName("정상 - 참여 신청 수락, 마감 x")
     void manageJoinRecruit_JOIN_RECRUIT_ACCEPTED() {
-      ParticipantManage.Request request =
-          new Request(true, member.getMemberId());
-      ParticipantEntity participant = ParticipantEntity.builder()
-          .participantId(1L)
-          .member(member)
-          .recruit(recruit)
-          .registeredAt(LocalDateTime.now().minusHours(1L))
-          .confirmedAt(LocalDateTime.now())
-          .build();
-
-      MemberEntity applicant = MemberEntity.builder()
-          .memberId(2L)
-          .accountName(TEST_STRING)
-          .name(TEST_STRING)
-          .email("test@test.com")
-          .password(TEST_STRING)
-          .phoneNumber("010-1111-2222")
-          .birthDate(LocalDate.now())
-          .gender(Gender.MALE)
-          .role(Role.USER)
-          .profileOpen(true)
-          .build();
+      MemberEntity writer = createMember(1L);
+      RecruitEntity recruit = createRecruit(10L, writer);
+      recruit.setCurrentCount(2);
 
       //given
-      when(memberRepository.findById(anyLong()))
+      MemberEntity applicant = createMember(2L);
+      ParticipantEntity participant = createParticipant(100L, applicant, recruit);
+      participant.setStatus(ParticipantStatus.ING);
+
+      ParticipantManage.Request request =
+          new Request(true, applicant.getMemberId());
+
+      when(memberRepository.findById(2L))
           .thenReturn(Optional.of(applicant));
-      when(recruitRepository.findById(anyLong()))
+      when(recruitRepository.findById(10L))
           .thenReturn(Optional.of(recruit));
       when(participantRepository.findByMemberAndRecruitAndStatus(
-          any(MemberEntity.class), any(RecruitEntity.class), any(ParticipantStatus.class)))
+          applicant, recruit, ParticipantStatus.ING))
           .thenReturn(Optional.of(participant));
 
       //when
       ParticipantManage.Response response =
           participantService.manageJoinRecruit(
-              request, recruit.getRecruitId(), member.getMemberId());
+              request, recruit.getRecruitId(), writer.getMemberId());
 
       //then
-      verify(participantRepository, never()).delete(any(ParticipantEntity.class));
-      verify(participantRepository, times(1)).save(any(ParticipantEntity.class));
+      verify(participantRepository, times(1)).save(participant);
+      verify(recruitRepository, times(1)).save(recruit);
+
+      log.info("recruit : {}", recruit);
+      assertThat(participant.getStatus()).isEqualTo(ParticipantStatus.ACCEPTED); //confirm()
+      assertThat(recruit.getCurrentCount()).isEqualTo(3);//participantAdded()
 
       assertThat(response.getRecruitId()).isEqualTo(recruit.getRecruitId());
       assertThat(response.getApplicantId()).isEqualTo(applicant.getMemberId());
       assertThat(response.getMessage()).isEqualTo(ResponseConstant.JOIN_RECRUIT_ACCEPTED);
-      assertThat(participant.getStatus()).isEqualTo(ParticipantStatus.ACCEPTED);
     }
 
     @Test
-    @DisplayName("거절")
-    void manageJoinRecruit_JOIN_RECRUIT_REJECTED() {
-      ParticipantManage.Request request =
-          new Request(false, member.getMemberId());
-      ParticipantEntity participant = ParticipantEntity.builder()
-          .participantId(1L)
-          .member(member)
-          .recruit(recruit)
-          .registeredAt(LocalDateTime.now().minusHours(1L))
-          .confirmedAt(LocalDateTime.now())
-          .build();
-
-      MemberEntity applicant = MemberEntity.builder()
-          .memberId(2L)
-          .accountName(TEST_STRING)
-          .name(TEST_STRING)
-          .email("test@test.com")
-          .password(TEST_STRING)
-          .phoneNumber("010-1111-2222")
-          .birthDate(LocalDate.now())
-          .gender(Gender.MALE)
-          .role(Role.USER)
-          .profileOpen(true)
-          .build();
+    @DisplayName("정상 - 참여 신청 수락, 마감 o")
+    void manageJoinRecruit_JOIN_RECRUIT_ACCEPTED_Recruit_END() {
+      MemberEntity writer = createMember(1L);
+      RecruitEntity recruit = createRecruit(10L, writer);
+      recruit.setCurrentCount(9);
 
       //given
-      when(memberRepository.findById(anyLong()))
+      MemberEntity applicant = createMember(2L);
+      ParticipantEntity participant = createParticipant(100L, applicant, recruit);
+      participant.setStatus(ParticipantStatus.ING);
+
+      ParticipantManage.Request request =
+          new Request(true, applicant.getMemberId());
+
+      when(memberRepository.findById(2L))
           .thenReturn(Optional.of(applicant));
-      when(recruitRepository.findById(anyLong()))
+      when(recruitRepository.findById(10L))
           .thenReturn(Optional.of(recruit));
       when(participantRepository.findByMemberAndRecruitAndStatus(
-          any(MemberEntity.class), any(RecruitEntity.class), any(ParticipantStatus.class)))
+          applicant, recruit, ParticipantStatus.ING))
           .thenReturn(Optional.of(participant));
 
       //when
       ParticipantManage.Response response =
           participantService.manageJoinRecruit(
-              request, recruit.getRecruitId(), member.getMemberId());
+              request, recruit.getRecruitId(), writer.getMemberId());
 
       //then
-      verify(participantRepository, times(1)).save(any(ParticipantEntity.class));
+      verify(participantRepository, times(1)).save(participant);
+      verify(recruitRepository, times(1)).save(recruit);
+
+      log.info("recruit : {}", recruit);
+      assertThat(participant.getStatus()).isEqualTo(ParticipantStatus.ACCEPTED); //confirm()
+      assertThat(recruit.getCurrentCount()).isEqualTo(10);//participantAdded()
+      assertThat(recruit.getRecruitStatus()).isEqualTo(RecruitStatus.END); //statusToEnd()
+
+      assertThat(response.getRecruitId()).isEqualTo(recruit.getRecruitId());
+      assertThat(response.getApplicantId()).isEqualTo(applicant.getMemberId());
+      assertThat(response.getMessage()).isEqualTo(ResponseConstant.JOIN_RECRUIT_ACCEPTED);
+    }
+
+    @Test
+    @DisplayName("정상 : 참여 신청 거절")
+    void manageJoinRecruit_JOIN_RECRUIT_REJECTED() {
+      MemberEntity writer = createMember(1L);
+      RecruitEntity recruit = createRecruit(10L, writer);
+
+      //given
+      MemberEntity applicant = createMember(2L);
+      ParticipantEntity participant = createParticipant(100L, applicant, recruit);
+      participant.setStatus(ParticipantStatus.ING);
+
+      ParticipantManage.Request request =
+          new Request(false, applicant.getMemberId());
+
+      when(memberRepository.findById(2L))
+          .thenReturn(Optional.of(applicant));
+      when(recruitRepository.findById(10L))
+          .thenReturn(Optional.of(recruit));
+      when(participantRepository.findByMemberAndRecruitAndStatus(
+          applicant, recruit, ParticipantStatus.ING))
+          .thenReturn(Optional.of(participant));
+
+      //when
+      ParticipantManage.Response response =
+          participantService.manageJoinRecruit(
+              request, recruit.getRecruitId(), writer.getMemberId());
+
+      //then
+      verify(participantRepository, times(1)).save(participant);
+      assertThat(participant.getStatus()).isEqualTo(ParticipantStatus.REFUSED);//refuse()
 
       assertThat(response.getRecruitId()).isEqualTo(recruit.getRecruitId());
       assertThat(response.getApplicantId()).isEqualTo(applicant.getMemberId());
       assertThat(response.getMessage()).isEqualTo(ResponseConstant.JOIN_RECRUIT_REJECTED);
-      assertThat(participant.getStatus()).isEqualTo(ParticipantStatus.REFUSED);
     }
+
+    @Test
+    @DisplayName("실패 - RECRUIT_ALREADY_END")
+    void manageJoinRecruit_RECRUIT_ALREADY_END() {
+      MemberEntity writer = createMember(1L);
+      RecruitEntity recruit = createRecruit(10L, writer);
+      recruit.setRecruitStatus(RecruitStatus.END);
+
+      //given
+      MemberEntity applicant = createMember(2L);
+      ParticipantEntity participant = createParticipant(100L, applicant, recruit);
+      participant.setStatus(ParticipantStatus.ING);
+
+      ParticipantManage.Request request =
+          new Request(false, applicant.getMemberId());
+
+      when(memberRepository.findById(2L))
+          .thenReturn(Optional.of(applicant));
+      when(recruitRepository.findById(10L))
+          .thenReturn(Optional.of(recruit));
+
+      //when
+      //then
+      RecruitException exception =
+          catchThrowableOfType(() ->
+              participantService.manageJoinRecruit(
+                  request, recruit.getRecruitId(), writer.getMemberId()), RecruitException.class);
+
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.RECRUIT_ALREADY_END);
+    }
+
+    @Test
+    @DisplayName("실패 - APPLICANT_MEMBER_NOT_FOUND")
+    void manageJoinRecruit_APPLICANT_MEMBER_NOT_FOUND() {
+      MemberEntity writer = createMember(1L);
+      RecruitEntity recruit = createRecruit(10L, writer);
+
+      //given
+      MemberEntity applicant = createMember(2L);
+      ParticipantEntity participant = createParticipant(100L, applicant, recruit);
+      participant.setStatus(ParticipantStatus.ING);
+
+      ParticipantManage.Request request =
+          new Request(false, 3L);
+
+      when(memberRepository.findById(3L))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      MemberException exception =
+          catchThrowableOfType(() ->
+              participantService.manageJoinRecruit(
+                  request, recruit.getRecruitId(), writer.getMemberId()), MemberException.class);
+
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.APPLICANT_MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패 - RECRUIT_NOT_FOUND")
+    void manageJoinRecruit_RECRUIT_NOT_FOUND() {
+      MemberEntity writer = createMember(1L);
+      RecruitEntity recruit = createRecruit(10L, writer);
+
+      //given
+      MemberEntity applicant = createMember(2L);
+      ParticipantEntity participant = createParticipant(100L, applicant, recruit);
+      participant.setStatus(ParticipantStatus.ING);
+
+      ParticipantManage.Request request =
+          new Request(false, applicant.getMemberId());
+
+      when(memberRepository.findById(2L))
+          .thenReturn(Optional.of(applicant));
+      when(recruitRepository.findById(11L))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      RecruitException exception =
+          catchThrowableOfType(() ->
+              participantService.manageJoinRecruit(
+                  request, 11L, writer.getMemberId()), RecruitException.class);
+
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.RECRUIT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패 - PARTICIPANT_NOT_FOUND")
+    void manageJoinRecruit_PARTICIPANT_NOT_FOUND() {
+      MemberEntity writer = createMember(1L);
+      RecruitEntity recruit = createRecruit(10L, writer);
+
+      //given
+      MemberEntity applicant = createMember(2L);
+
+      ParticipantManage.Request request =
+          new Request(false, applicant.getMemberId());
+
+      when(memberRepository.findById(2L))
+          .thenReturn(Optional.of(applicant));
+      when(recruitRepository.findById(10L))
+          .thenReturn(Optional.of(recruit));
+      when(participantRepository.findByMemberAndRecruitAndStatus(
+          applicant, recruit, ParticipantStatus.ING))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      ParticipantException exception =
+          catchThrowableOfType(() ->
+                  participantService.manageJoinRecruit(
+                      request, recruit.getRecruitId(), writer.getMemberId()),
+              ParticipantException.class);
+
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PARTICIPANT_NOT_FOUND);
+    }
+
   }
 
   @Nested

--- a/src/test/java/com/anonymous/usports/domain/participant/service/ParticipantServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/participant/service/ParticipantServiceTest.java
@@ -215,7 +215,7 @@ class ParticipantServiceTest {
           participantService.joinRecruit(member.getMemberId(), recruit.getRecruitId());
 
       //then
-      verify(participantRepository, times(1)).save(any(ParticipantEntity.class));
+      verify(participantRepository, times(1)).save(new ParticipantEntity(member, recruit));
 
       assertThat(response.getRecruitId()).isEqualTo(recruit.getRecruitId());
       assertThat(response.getMemberId()).isEqualTo(member.getMemberId());

--- a/src/test/java/com/anonymous/usports/domain/participant/service/ParticipantServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/participant/service/ParticipantServiceTest.java
@@ -63,11 +63,6 @@ class ParticipantServiceTest {
   @InjectMocks
   private ParticipantServiceImpl participantService;
 
-  static final String TEST_STRING = "test";
-  static MemberEntity member;
-  static SportsEntity sports;
-  static RecruitEntity recruit;
-
   private MemberEntity createMember(Long id) {
     return MemberEntity.builder()
         .memberId(id)
@@ -110,45 +105,6 @@ class ParticipantServiceTest {
         .member(member)
         .recruit(recruit)
         .registeredAt(LocalDateTime.now())
-        .build();
-  }
-
-  @BeforeEach
-  void init() {
-    member = MemberEntity.builder()
-        .memberId(1L)
-        .accountName(TEST_STRING)
-        .name(TEST_STRING)
-        .email("test@test.com")
-        .password(TEST_STRING)
-        .phoneNumber("010-1111-2222")
-        .birthDate(LocalDate.now())
-        .gender(Gender.MALE)
-        .role(Role.USER)
-        .profileOpen(true)
-        .build();
-
-    sports = SportsEntity.builder()
-        .sportsId(1L)
-        .sportsName(TEST_STRING)
-        .build();
-
-    recruit = RecruitEntity.builder()
-        .recruitId(1L)
-        .sports(sports)
-        .member(member)
-        .title(TEST_STRING)
-        .content(TEST_STRING)
-        .placeName(TEST_STRING)
-        .lat("111")
-        .lnt("11")
-        .cost(10000)
-        .gender(Gender.MALE)
-        .recruitCount(10)
-        .meetingDate(LocalDateTime.now())
-        .recruitStatus(RecruitStatus.RECRUITING)
-        .gradeFrom(1)
-        .gradeTo(10)
         .build();
   }
 

--- a/src/test/java/com/anonymous/usports/domain/participant/service/ParticipantServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/participant/service/ParticipantServiceTest.java
@@ -413,7 +413,7 @@ class ParticipantServiceTest {
       log.info("recruit : {}", recruit);
       assertThat(participant.getStatus()).isEqualTo(ParticipantStatus.ACCEPTED); //confirm()
       assertThat(recruit.getCurrentCount()).isEqualTo(10);//participantAdded()
-      assertThat(recruit.getRecruitStatus()).isEqualTo(RecruitStatus.END); //statusToEnd()
+      assertThat(recruit.getRecruitStatus()).isEqualTo(RecruitStatus.END);
 
       assertThat(response.getRecruitId()).isEqualTo(recruit.getRecruitId());
       assertThat(response.getApplicantId()).isEqualTo(applicant.getMemberId());

--- a/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.domain.participant.repository.ParticipantRepository;
 import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister;
@@ -49,6 +50,8 @@ class RecruitServiceTest {
   private SportsRepository sportsRepository;
   @Mock
   private RecruitRepository recruitRepository;
+  @Mock
+  private ParticipantRepository participantRepository;
 
   @InjectMocks
   private RecruitServiceImpl recruitService;

--- a/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
@@ -66,7 +66,6 @@ class RecruitServiceTest {
         .phoneNumber("010-1111-2222")
         .birthDate(LocalDate.now())
         .gender(Gender.MALE)
-        .status(MemberStatus.NEED_UPDATE)
         .role(Role.USER)
         .profileOpen(true)
         .build();


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**[모집글 참여 신청 취소]**
- ING / ACCEPTED 상태를 순차적으로 찾는다.
- 둘중 하나라도 먼저 찾으면 해당 신청 내역을 삭제한다.
- 참여 신청은 ING, ACCEPTED, REFUSED로 나눠지는데, ING 와 ACCEPTED는 하나만 존재할 수 있기 때문이다.

**[테스트]**
아래 세 개의 리뷰를 받았다.
- 테스트 케이스는 모든 예외상황까지 테스트를 해야지 의미가 있다.
- any(), anyLong() 등은 사용하지 않는게 좋다.
- 테스트를 위한 엔티티에 같은 값을 넣지 마라 ( title = "test", content = "test", name = "test" 처럼 같은 값을 대충 넣는 것)

이에 따라 ParticipantService, RecruitService의 모든 메서드의 모든 예외 사항에 대한 테스트 코드를 작성하였다.

- @BeforeEach에서 엔티티를 생성하여 static field에 저장하는 방식보다 private 메서드로 엔티티를 생성하는 방식이 더 효율적이라고 판단하여 수정하였다.


**[entity register 시 문제 발생]**
처음으로 엔티티를 등록하는 경우, request.toEntity()의 주소와, save 메서드 실행 후 반환되는 엔티티의 주소가 달라서 문제가 발생했다.
- Entity class에 @EqualsAndHashcode를 추가하여 해결하였다.
- 이 어노테이션은 조금 더 조심히 다뤄야 하기 때문에 추후에(빠른 시일 내로) 해당 내용 공부 후 직접 구현하는 방식으로 수정 할 예정이다.


### 테스트 여부
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 
