### PR TITLE
운동 모집 게시글 검색 기능 구현, 테스트

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/participant/dto/ParticipantListDto.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/dto/ParticipantListDto.java
@@ -19,29 +19,22 @@ import org.springframework.data.domain.Page;
 @Builder
 public class ParticipantListDto {
 
-  private int currentPage; //현재 페이지
-
-  private int pageSize; //페이지 당 데이터 개수
-
-  private int totalPages; // 전체 페이지 수
-
-  private int totalElements; //전체 데이터 개수
-
+  private int currentPage;//현재 페이지
+  private int currentElements;//현재 페이지 데이터 개수
+  private int pageSize; //한 페이지의 크기
+  private int totalElement;//전체 데이터 개수
+  private int totalPages;//전체 페이지 개수
 
   private List<ParticipantDto> list;
 
-  public static ParticipantListDto fromEntityPage(Page<ParticipantEntity> participantEntityPage) {
-    return ParticipantListDto.builder()
-        .currentPage(participantEntityPage.getNumber() + 1)
-        .pageSize(participantEntityPage.getSize())
-        .totalPages(participantEntityPage.getTotalPages())
-        .totalElements((int) participantEntityPage.getTotalElements())
-        .list(participantEntityPage.getContent()
-            .stream()
-            .map(ParticipantDto::fromEntity)
-            .collect(Collectors.toList())
-        )
-        .build();
+  public ParticipantListDto(Page<ParticipantEntity> page) {
+    this.currentPage = page.getNumber() + 1;
+    this.currentElements = page.getNumberOfElements();
+    this.pageSize = page.getSize();
+    this.totalElement = (int) page.getTotalElements();
+    this.totalPages = page.getTotalPages();
+    this.list = page.getContent().stream().map(ParticipantDto::fromEntity)
+        .collect(Collectors.toList());
   }
 
 }

--- a/src/main/java/com/anonymous/usports/domain/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/service/impl/ParticipantServiceImpl.java
@@ -52,7 +52,7 @@ public class ParticipantServiceImpl implements ParticipantService {
         participantRepository.findAllByRecruitAndStatusOrderByParticipantId(
             recruitEntity, ParticipantStatus.ING, pageRequest);
 
-    return ParticipantListDto.fromEntityPage(findPage);
+    return new ParticipantListDto(findPage);
   }
 
   @Override

--- a/src/main/java/com/anonymous/usports/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/controller/RecruitController.java
@@ -5,6 +5,7 @@ import com.anonymous.usports.domain.recruit.dto.RecruitDeleteResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister;
+import com.anonymous.usports.domain.recruit.dto.RecruitSearchListDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitUpdate;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.domain.recruit.service.RecruitService;
@@ -93,7 +94,7 @@ public class RecruitController {
 
   @ApiOperation("운동 모집글 검색")
   @GetMapping("/recruits")
-  public ResponseEntity<?> getRecruitList(
+  public ResponseEntity<RecruitSearchListDto> getRecruitList(
       @RequestParam(required = false, defaultValue = "1") int page,
       @RequestParam(required = false) String search,
       @RequestParam(required = false) String region,
@@ -102,10 +103,10 @@ public class RecruitController {
       @RequestParam(required = false) boolean closeInclude
       ){
 
-    Page<RecruitEntity> recruits = recruitService.getRecruitsByConditions(page, search,
-        region, sports, gender, closeInclude);
+    RecruitSearchListDto result =
+        recruitService.getRecruitsByConditions(page, search, region, sports, gender, closeInclude);
 
-    return ResponseEntity.ok(recruits);
+    return ResponseEntity.ok(result);
   }
 
 

--- a/src/main/java/com/anonymous/usports/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/controller/RecruitController.java
@@ -6,12 +6,15 @@ import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister;
 import com.anonymous.usports.domain.recruit.dto.RecruitUpdate;
+import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.domain.recruit.service.RecruitService;
+import com.anonymous.usports.global.type.Gender;
 import io.swagger.annotations.ApiOperation;
 import javax.persistence.criteria.CriteriaBuilder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Criteria;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -89,20 +92,20 @@ public class RecruitController {
   }
 
   @ApiOperation("운동 모집글 검색")
-  @GetMapping("/recruits/{page}")
+  @GetMapping("/recruits")
   public ResponseEntity<?> getRecruitList(
       @RequestParam(required = false, defaultValue = "1") int page,
       @RequestParam(required = false) String search,
-      @RequestParam(required = false) String place,
+      @RequestParam(required = false) String region,
       @RequestParam(required = false) String sports,
-      @RequestParam(required = false) String gender,
-      @RequestParam(required = false) String close
+      @RequestParam(required = false) Gender gender,
+      @RequestParam(required = false) boolean closeInclude
       ){
 
-    recruitService.getRecruitsByConditions(page, search, place, sports, gender, close);
+    Page<RecruitEntity> recruits = recruitService.getRecruitsByConditions(page, search,
+        region, sports, gender, closeInclude);
 
-
-      return ResponseEntity.ok(null);
+    return ResponseEntity.ok(recruits);
   }
 
 

--- a/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitDto.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitDto.java
@@ -42,6 +42,12 @@ public class RecruitDto {
 
   private String placeName;
 
+  private String region;
+
+  private String streetNameAddr; // 도로명 주소
+
+  private String streetNumberAddr; // 지번 주소
+
   private String lat;
 
   private String lnt;
@@ -72,6 +78,9 @@ public class RecruitDto {
         .title(recruitEntity.getTitle())
         .content(recruitEntity.getContent())
         .placeName(recruitEntity.getPlaceName())
+        .region(recruitEntity.getRegion())
+        .streetNameAddr(recruitEntity.getStreetNameAddr())
+        .streetNumberAddr(recruitEntity.getStreetNumberAddr())
         .lat(recruitEntity.getLat())
         .lnt(recruitEntity.getLnt())
         .cost(recruitEntity.getCost())

--- a/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitRegister.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitRegister.java
@@ -26,6 +26,9 @@ public class RecruitRegister {
     private String title;
     private String content;
     private String placeName;
+    private String region;
+    private String streetNameAddr;
+    private String streetNumberAddr;
     private String lat;
     private String lnt;
     private int cost;
@@ -45,6 +48,9 @@ public class RecruitRegister {
           .title(request.getTitle())
           .content(request.getContent())
           .placeName(request.getPlaceName())
+          .region(request.getRegion())
+          .streetNameAddr(request.getStreetNameAddr())
+          .streetNumberAddr(request.getStreetNumberAddr())
           .lat(request.getLat())
           .lnt(request.getLnt())
           .cost(request.getCost())

--- a/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitSearchListDto.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitSearchListDto.java
@@ -1,0 +1,38 @@
+package com.anonymous.usports.domain.recruit.dto;
+
+import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RecruitSearchListDto {
+
+  private int currentPage;//현재 페이지
+  private int currentElements;//현재 페이지 데이터 개수
+  private int pageSize; //한 페이지의 크기
+  private int totalElement;//전체 데이터 개수
+  private int totalPages;//전체 페이지 개수
+
+  List<RecruitDto> list;
+
+  public RecruitSearchListDto(Page<RecruitEntity> page) {
+    this.currentPage = page.getNumber() + 1;
+    this.currentElements = page.getNumberOfElements();
+    this.pageSize = page.getSize();
+    this.totalElement = (int)page.getTotalElements();
+    this.totalPages = page.getTotalPages();
+    this.list = page.getContent().stream().map(RecruitDto::fromEntity).collect(Collectors.toList());
+  }
+
+
+}

--- a/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitUpdate.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitUpdate.java
@@ -3,6 +3,7 @@ package com.anonymous.usports.domain.recruit.dto;
 import com.anonymous.usports.global.constant.ResponseConstant;
 import com.anonymous.usports.global.type.Gender;
 import java.time.LocalDateTime;
+import javax.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,8 +22,12 @@ public class RecruitUpdate {
     private String title;
     private String content;
     private String placeName;
+    private String region;
+    private String streetNameAddr; // 도로명 주소
+    private String streetNumberAddr; // 지번 주소
     private String lat;
     private String lnt;
+
     private int cost;
     private Gender gender;
     private int recruitCount;

--- a/src/main/java/com/anonymous/usports/domain/recruit/entity/RecruitEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/entity/RecruitEntity.java
@@ -62,6 +62,15 @@ public class RecruitEntity {
   @Column(name = "place_name", nullable = false)
   private String placeName;
 
+  @Column(name = "region", nullable = false)
+  private String region;
+
+  @Column(name = "street_name_addr")
+  private String streetNameAddr; // 도로명 주소
+
+  @Column(name = "street_number_addr")
+  private String streetNumberAddr; // 지번 주소
+
   @Column(name = "lat", nullable = false)
   private String lat;
 
@@ -107,6 +116,9 @@ public class RecruitEntity {
     this.title = request.getTitle();
     this.content = request.getContent();
     this.placeName = request.getPlaceName();
+    this.region = request.getRegion();
+    this.streetNameAddr = request.getStreetNameAddr();
+    this.streetNumberAddr = request.getStreetNumberAddr();
     this.lat = request.getLat();
     this.lnt = request.getLnt();
     this.cost = request.getCost();

--- a/src/main/java/com/anonymous/usports/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/repository/RecruitRepository.java
@@ -1,10 +1,42 @@
 package com.anonymous.usports.domain.recruit.repository;
 
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
+import com.anonymous.usports.domain.sports.entity.SportsEntity;
+import com.anonymous.usports.global.type.Gender;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecruitRepository extends JpaRepository<RecruitEntity, Long>{
+
+
+  @Query("SELECT r from recruit r "
+      + " WHERE (:search is null or r.title like concat('%', :search, '%')) "
+      + " and (:region is null or r.region = :region) "
+      + " and (:sports is null or r.sports = :sports) "
+      + " and (:gender is null or r.gender = :gender)")
+  Page<RecruitEntity> findAllByConditionIncludeEND(
+      @Param("search") String search,
+      @Param("region") String region,
+      @Param("sports") SportsEntity sports,
+      @Param("gender") Gender gender,
+      Pageable pageable);
+
+  @Query("SELECT r from recruit r "
+      + " WHERE (:search is null or r.title like concat('%', :search, '%')) "
+      + " and (:region is null or r.region = :region) "
+      + " and (:sports is null or r.sports = :sports) "
+      + " and (:gender is null or r.gender = :gender) "
+      + " and (r.recruitStatus != 'END')")
+  Page<RecruitEntity> findAllByConditionNotIncludeEND(
+      @Param("search") String search,
+      @Param("region") String region,
+      @Param("sports") SportsEntity sports,
+      @Param("gender") Gender gender,
+      Pageable pageable);
 
 }

--- a/src/main/java/com/anonymous/usports/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/service/RecruitService.java
@@ -5,6 +5,9 @@ import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister;
 import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitUpdate;
+import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
+import com.anonymous.usports.global.type.Gender;
+import org.springframework.data.domain.Page;
 
 public interface RecruitService {
 
@@ -36,7 +39,7 @@ public interface RecruitService {
   /**
    * 여러 조건에 따른 Recruit 리스트 반환
    */
-  void getRecruitsByConditions(
-      int page, String search, String place, String sports, String gender, String close);
+  Page<RecruitEntity> getRecruitsByConditions(
+      int page, String search, String region, String sports, Gender gender, boolean closeInclude);
 
 }

--- a/src/main/java/com/anonymous/usports/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/service/RecruitService.java
@@ -4,6 +4,7 @@ package com.anonymous.usports.domain.recruit.service;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister;
 import com.anonymous.usports.domain.recruit.dto.RecruitDto;
+import com.anonymous.usports.domain.recruit.dto.RecruitSearchListDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitUpdate;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.global.type.Gender;
@@ -39,7 +40,7 @@ public interface RecruitService {
   /**
    * 여러 조건에 따른 Recruit 리스트 반환
    */
-  Page<RecruitEntity> getRecruitsByConditions(
+  RecruitSearchListDto getRecruitsByConditions(
       int page, String search, String region, String sports, Gender gender, boolean closeInclude);
 
 }

--- a/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
@@ -12,18 +12,25 @@ import com.anonymous.usports.domain.recruit.repository.RecruitRepository;
 import com.anonymous.usports.domain.recruit.service.RecruitService;
 import com.anonymous.usports.domain.sports.entity.SportsEntity;
 import com.anonymous.usports.domain.sports.repository.SportsRepository;
+import com.anonymous.usports.global.constant.NumberConstant;
 import com.anonymous.usports.global.constant.ResponseConstant;
 import com.anonymous.usports.global.exception.ErrorCode;
 import com.anonymous.usports.global.exception.MemberException;
 import com.anonymous.usports.global.exception.MyException;
 import com.anonymous.usports.global.exception.RecruitException;
 import com.anonymous.usports.global.exception.SportsException;
+import com.anonymous.usports.global.type.Gender;
 import com.anonymous.usports.global.type.RecruitStatus;
+import io.jsonwebtoken.lang.Strings;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -130,9 +137,33 @@ public class RecruitServiceImpl implements RecruitService {
 
   @Override
   @Transactional
-  public void getRecruitsByConditions(int page, String search, String place, String sports,
-      String gender, String close) {
+  public Page<RecruitEntity> getRecruitsByConditions(
+      int page, String search, String region, String sports, Gender gender, boolean closeInclude) {
 
+    if (!StringUtils.hasText(search)) {
+      search = null;
+    }
+    if (!StringUtils.hasText(region)) {
+      region = null;
+    }
+    SportsEntity sportsEntity = null;
+    if (Strings.hasText(sports)) {
+      sportsEntity = sportsRepository.findBySportsName(sports)
+          .orElseThrow(() -> new SportsException(ErrorCode.SPORTS_NOT_FOUND));
+    }
+    PageRequest pageRequest = PageRequest.of(page - 1, NumberConstant.PAGE_SIZE_DEFAULT, Sort.by("registeredAt").descending());
+
+    Page<RecruitEntity> findPage = Page.empty();
+
+    if(closeInclude){
+      findPage = recruitRepository.findAllByConditionIncludeEND(
+          search, region, sportsEntity, gender, pageRequest);
+    }else{
+      findPage = recruitRepository.findAllByConditionNotIncludeEND(
+          search, region, sportsEntity, gender, pageRequest);
+    }
+
+    return findPage;
   }
 
   private void validateAuthority(MemberEntity member, Long memberId) {

--- a/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
@@ -6,6 +6,7 @@ import com.anonymous.usports.domain.participant.repository.ParticipantRepository
 import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister.Request;
+import com.anonymous.usports.domain.recruit.dto.RecruitSearchListDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitUpdate;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.domain.recruit.repository.RecruitRepository;
@@ -137,7 +138,7 @@ public class RecruitServiceImpl implements RecruitService {
 
   @Override
   @Transactional
-  public Page<RecruitEntity> getRecruitsByConditions(
+  public RecruitSearchListDto getRecruitsByConditions(
       int page, String search, String region, String sports, Gender gender, boolean closeInclude) {
 
     if (!StringUtils.hasText(search)) {
@@ -163,7 +164,7 @@ public class RecruitServiceImpl implements RecruitService {
           search, region, sportsEntity, gender, pageRequest);
     }
 
-    return findPage;
+    return new RecruitSearchListDto(findPage);
   }
 
   private void validateAuthority(MemberEntity member, Long memberId) {

--- a/src/main/java/com/anonymous/usports/domain/sports/repository/SportsRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/sports/repository/SportsRepository.java
@@ -1,10 +1,11 @@
 package com.anonymous.usports.domain.sports.repository;
 
 import com.anonymous.usports.domain.sports.entity.SportsEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SportsRepository extends JpaRepository<SportsEntity, Long> {
-
+  Optional<SportsEntity> findBySportsName(String sportsName);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,6 +11,8 @@ spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 
+spring.jackson.serialization.fail-on-empty-beans=false
+
 spring.redis.host=localhost
 spring.redis.port=6379
 

--- a/src/test/java/com/anonymous/usports/domain/participant/service/ParticipantServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/participant/service/ParticipantServiceTest.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -147,7 +146,7 @@ class ParticipantServiceTest {
       assertThat(participants.getCurrentPage()).isEqualTo(1);
       assertThat(participants.getPageSize()).isEqualTo(7);
       assertThat(participants.getTotalPages()).isEqualTo(1);
-      assertThat(participants.getTotalElements()).isEqualTo(7);
+      assertThat(participants.getTotalElement()).isEqualTo(7);
 
       List<ParticipantDto> list = participants.getList();
       for (int i = 0; i < list.size(); i++) {

--- a/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
@@ -13,12 +13,14 @@ import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister.Request;
+import com.anonymous.usports.domain.recruit.dto.RecruitSearchListDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitUpdate;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.domain.recruit.repository.RecruitRepository;
 import com.anonymous.usports.domain.recruit.service.impl.RecruitServiceImpl;
 import com.anonymous.usports.domain.sports.entity.SportsEntity;
 import com.anonymous.usports.domain.sports.repository.SportsRepository;
+import com.anonymous.usports.global.constant.NumberConstant;
 import com.anonymous.usports.global.constant.ResponseConstant;
 import com.anonymous.usports.global.exception.ErrorCode;
 import com.anonymous.usports.global.exception.MemberException;
@@ -30,6 +32,8 @@ import com.anonymous.usports.global.type.RecruitStatus;
 import com.anonymous.usports.global.type.Role;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -39,6 +43,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 @Slf4j
 @ExtendWith(MockitoExtension.class)
@@ -87,13 +94,17 @@ class RecruitServiceTest {
         .recruitCount(10)
         .meetingDate(LocalDateTime.now())
         .recruitStatus(RecruitStatus.RECRUITING)
+        .registeredAt(LocalDateTime.now())
         .gradeFrom(1)
         .gradeTo(10)
         .build();
   }
-
   private SportsEntity createSports(Long id) {
-    return new SportsEntity(id, "sportsName");
+    return new SportsEntity(id, "football");
+  }
+
+  private SportsEntity createSports(Long id, String sportsName) {
+    return new SportsEntity(id, sportsName);
   }
 
   @Nested
@@ -587,6 +598,90 @@ class RecruitServiceTest {
 
       assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NO_AUTHORITY_ERROR);
     }
+  }
 
+  @Nested
+  @DisplayName("Recruit 필터링 검색")
+  class GetRecruitsByConditions{
+    @Test
+    @DisplayName("성공")
+    void getRecruitsByConditions(){
+      MemberEntity memberEntity = createMember(1L);
+      SportsEntity football = createSports(1000L, "축구");
+      List<RecruitEntity> recruitList = new ArrayList<>();
+
+      int page = 1;
+      String search = "title";
+      String region = "대구";
+      String footballString = "축구";
+      Gender gender = Gender.MALE;
+      boolean closeInclude = false;
+
+      for(long i = 101; i <= 108; i++){
+        RecruitEntity recruit = createRecruit(i, memberEntity, football);
+        recruit.setRegion(region);
+        recruit.setGender(gender);
+        recruitList.add(recruit);
+      }
+      //given
+      when(sportsRepository.findBySportsName(footballString))
+          .thenReturn(Optional.of(football));
+
+      when(recruitRepository.findAllByConditionNotIncludeEND(
+          search, region, football, gender,
+          PageRequest.of(page - 1, NumberConstant.PAGE_SIZE_DEFAULT, Sort.by("registeredAt").descending())))
+          .thenReturn(new PageImpl<>(recruitList));
+      //when
+      RecruitSearchListDto result =
+          recruitService.getRecruitsByConditions(
+              page, search, region, footballString, gender, closeInclude);
+
+      //then
+      assertThat(result.getCurrentElements()).isEqualTo(8);
+      assertThat(result.getTotalPages()).isEqualTo(1);
+      List<RecruitDto> list = result.getList();
+      for (RecruitDto r : list){
+        assertThat(r.getTitle().contains(search)).isTrue();
+        assertThat(r.getRegion()).isEqualTo(region);
+        assertThat(r.getSportsId()).isEqualTo(football.getSportsId());
+        assertThat(r.getGender()).isEqualTo(Gender.MALE);
+        assertThat(r.getRecruitStatus()).isNotEqualTo(RecruitStatus.END);
+      }
+    }
+
+    @Test
+    @DisplayName("실패 - SPORTS_NOT_FOUND")
+    void getRecruitsByConditions_SPORTS_NOT_FOUND(){
+      MemberEntity memberEntity = createMember(1L);
+      SportsEntity football = createSports(1000L, "축구");
+      List<RecruitEntity> recruitList = new ArrayList<>();
+
+      int page = 1;
+      String search = "title";
+      String region = "대구";
+      String footballString = "축구";
+      Gender gender = Gender.MALE;
+      boolean closeInclude = false;
+
+      for(long i = 101; i <= 108; i++){
+        RecruitEntity recruit = createRecruit(i, memberEntity, football);
+        recruit.setRegion(region);
+        recruit.setGender(gender);
+        recruitList.add(recruit);
+      }
+      //given
+      when(sportsRepository.findBySportsName(footballString))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      SportsException exception =
+          catchThrowableOfType(() ->
+              recruitService.getRecruitsByConditions(
+                  page, search, region, footballString, gender, closeInclude), SportsException.class);
+
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SPORTS_NOT_FOUND);
+
+    }
   }
 }


### PR DESCRIPTION
### 변경사항
**[게시글 필터링 구현(조건 별 검색)]**
- 게시글을 필터링하여 Page<RecruitEntity>를 반환하는 것 까지 완료
- JPQL(@Query)을 이용해서 각 검색 조건들이 null인 경우 처리
- "마감 글 포함" 항목은 따로 구분이 어려워서 해당 조건을 기준으로 두개의 Repository로 분리
(주의)
- String은 request가 들어올 때 null이 아니라 ""가 들어오는 경우도 있기 때문에 Strings.hasText()로 구분할 것
- Repository에서는 null인 경우에 제외하도록 했기 때문에 주의해야 함

**[게시글 필터링 구현완료]**
- 위에서 받은 Page<RecruitEntity>를 원하는 형식의 DTO로 변환
- 프론트에서 필요한 부분은 아래와 같음
    - 현재 페이지 
    - 현재 페이지의 데이터 개수 
    - 전체 데이터 개수
    - 전체 페이지 개수
    - 한 페이지의 크기(필수는 아닌 것 같음) 
- 모두 Page<>에서 얻을 수 있는 데이터
- 추가로 이전에 만들었던 ParticipantListDto도 이번에 만든 RecruitSearchListDto와 형식을 맞춤

**[테스트코드 작성]**
- 이 메서드에 대한 테스트는 아무래도 mocking을 이용한 단위 테스트로는 검증이 어렵다고 생각됨.
- 통합 테스트를 고려해볼 만 하다.



### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 
