### PR TITLE
Feature/notification session

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/member/controller/MemberContoller.java
+++ b/src/main/java/com/anonymous/usports/domain/member/controller/MemberContoller.java
@@ -3,7 +3,9 @@ package com.anonymous.usports.domain.member.controller;
 import com.anonymous.usports.domain.member.dto.*;
 import com.anonymous.usports.domain.member.security.TokenProvider;
 import com.anonymous.usports.domain.member.service.MemberService;
+import com.anonymous.usports.domain.notification.service.NotificationService;
 import io.swagger.annotations.ApiOperation;
+import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -19,6 +21,7 @@ public class MemberContoller {
 
     private final MemberService memberService;
     private final TokenProvider tokenProvider;
+    private final NotificationService notificationService;
 
     /**
      * 회원 가입
@@ -40,10 +43,13 @@ public class MemberContoller {
     @PostMapping("/login")
     @ApiOperation(value = "회원 로그인 하기", notes = "access token과 refresh token 생성")
     public ResponseEntity<MemberLogin.Response> login(
-            @RequestBody MemberLogin.Request request
+            @RequestBody MemberLogin.Request request,
+        HttpServletRequest httpServletRequest
     ){
 
         MemberDto memberDto = memberService.loginMember(request);
+
+        notificationService.checkUnreadNotificationAndSetSession(memberDto.getMemberId(), httpServletRequest);
 
         return ResponseEntity.ok(MemberLogin.Response.builder()
                         .tokenDto(tokenProvider.saveTokenInRedis(memberDto.getEmail()))

--- a/src/main/java/com/anonymous/usports/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/anonymous/usports/domain/notification/controller/NotificationController.java
@@ -26,12 +26,8 @@ public class NotificationController {
       @AuthenticationPrincipal MemberDto loginMember,
       HttpServletRequest httpServletRequest) {
 
-    //FIXME : 테스트용
     List<NotificationDto> notifications =
-        notificationService.getNotifications(1L);//loginMember.getMemberId());
-
-//    List<NotificationDto> notifications =
-//        notificationService.getNotifications(loginMember.getMemberId());
+        notificationService.getNotifications(loginMember.getMemberId());
 
     //알림 리스트 조회 시 "안읽은 알림 없음 상태" 로 변경
     notificationService.setUnreadNotificationSession(httpServletRequest, false);

--- a/src/main/java/com/anonymous/usports/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/anonymous/usports/domain/notification/controller/NotificationController.java
@@ -5,11 +5,12 @@ import com.anonymous.usports.domain.notification.dto.NotificationDto;
 import com.anonymous.usports.domain.notification.service.NotificationService;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -21,11 +22,19 @@ public class NotificationController {
 
   @ApiOperation("알림 리스트 보기")
   @GetMapping("/notifications")
-  public ResponseEntity<List<NotificationDto>> notificationList(
-      @AuthenticationPrincipal MemberDto loginMember) {
+  public @ResponseBody ResponseEntity<?> notificationList(
+      @AuthenticationPrincipal MemberDto loginMember,
+      HttpServletRequest httpServletRequest) {
 
+    //FIXME : 테스트용
     List<NotificationDto> notifications =
-        notificationService.getNotifications(loginMember.getMemberId());
+        notificationService.getNotifications(1L);//loginMember.getMemberId());
+
+//    List<NotificationDto> notifications =
+//        notificationService.getNotifications(loginMember.getMemberId());
+
+    //알림 리스트 조회 시 "안읽은 알림 없음 상태" 로 변경
+    notificationService.setUnreadNotificationSession(httpServletRequest, false);
 
     return ResponseEntity.ok(notifications);
   }

--- a/src/main/java/com/anonymous/usports/domain/notification/controller/NotificationSseController.java
+++ b/src/main/java/com/anonymous/usports/domain/notification/controller/NotificationSseController.java
@@ -30,12 +30,11 @@ public class NotificationSseController {
   private final MemberRepository memberRepository;
 
   @ApiOperation(value = "구독을 시작하기 위한 메서드", notes = "테스트를 위해 id를 PathVariable로 설정했지만, 실제로는 loginMemberId를 사용")
-  @GetMapping(value = "/subscribe/{id}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
   public SseEmitter subscribe(@PathVariable Long id,
       @AuthenticationPrincipal MemberDto loginMember) {
-    //FIXME : {id} Pathvariable을 없애고, loginMember.getMemberId()로 변경하기
-    //return notificationService.subscribe(loginMember.getMemberId());
-    return notificationService.subscribe(id);
+
+    return notificationService.subscribe(loginMember.getMemberId());
   }
 
   /**

--- a/src/main/java/com/anonymous/usports/domain/notification/entity/NotificationEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/notification/entity/NotificationEntity.java
@@ -4,6 +4,7 @@ import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.global.type.NotificationEntityType;
 import com.anonymous.usports.global.type.NotificationType;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 
@@ -68,5 +69,22 @@ public class NotificationEntity{
 
   public void readNow(){
     this.readAt = LocalDateTime.now();
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || getClass() != object.getClass()) {
+      return false;
+    }
+    NotificationEntity that = (NotificationEntity) object;
+    return Objects.equals(notificationId, that.notificationId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(notificationId);
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/notification/repository/NotificationRepository.java
@@ -13,4 +13,6 @@ public interface NotificationRepository extends JpaRepository<NotificationEntity
   List<NotificationEntity> findByMemberOrderByCreatedAtDesc(MemberEntity member);
 
   Integer deleteAllByCreatedAtBefore(LocalDateTime time);
+
+  boolean existsByMemberAndReadAtIsNull(MemberEntity member);
 }

--- a/src/main/java/com/anonymous/usports/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/anonymous/usports/domain/notification/service/NotificationService.java
@@ -4,6 +4,7 @@ import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.notification.dto.NotificationCreateDto;
 import com.anonymous.usports.domain.notification.dto.NotificationDto;
 import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public interface NotificationService {
@@ -19,9 +20,14 @@ public interface NotificationService {
   SseEmitter subscribe(Long memberId);
 
   /**
-   * 서버의 이벤트를 클라이언트에게 보내는 메서드 - 이 메서드는 실제 알림을 보내는 곳에서 사용한다.
+   * 서버의 이벤트를 클라이언트에게 보내는 메서드 - 이 메서드는 실제 알림을 보내는 곳에서 사용한다. - 이 메서드 사용 시 꼭 컨트롤러 단에서
+   * HttpServletRequest를 받아서 setUnreadNotificationSession을 호출해야한다.
    */
   NotificationDto notify(MemberEntity member, NotificationCreateDto notificationCreateDto);
 
+  /**
+   * 세션의 unreadNotification 값 수정 (true : 안읽은 알림 있음 / false : 안읽은 알림 없음)
+   */
+  void setUnreadNotificationSession(HttpServletRequest httpServletRequest, boolean isUnread);
 
 }

--- a/src/main/java/com/anonymous/usports/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/anonymous/usports/domain/notification/service/NotificationService.java
@@ -30,4 +30,9 @@ public interface NotificationService {
    */
   void setUnreadNotificationSession(HttpServletRequest httpServletRequest, boolean isUnread);
 
+  /**
+   * Notification 중, 읽지 않은 알림이 있는지 확인 후 세션 값 세팅
+   */
+  void checkUnreadNotificationAndSetSession(Long memberId, HttpServletRequest httpServletRequest);
+
 }

--- a/src/main/java/com/anonymous/usports/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/anonymous/usports/domain/notification/service/NotificationService.java
@@ -33,6 +33,6 @@ public interface NotificationService {
   /**
    * Notification 중, 읽지 않은 알림이 있는지 확인 후 세션 값 세팅
    */
-  void checkUnreadNotificationAndSetSession(Long memberId, HttpServletRequest httpServletRequest);
+  boolean checkUnreadNotificationAndSetSession(Long memberId, HttpServletRequest httpServletRequest);
 
 }

--- a/src/main/java/com/anonymous/usports/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/notification/service/impl/NotificationServiceImpl.java
@@ -13,6 +13,8 @@ import com.anonymous.usports.global.exception.MemberException;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -27,6 +29,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEvent
 public class NotificationServiceImpl implements NotificationService {
 
   private static final Long DEFAULT_TIMEOUT = 1000 * 60 * 60L;
+  private static final String UNREAD_NOTIFICATION = "unreadNotification";
   private final EmitterRepository emitterRepository;
   private final NotificationRepository notificationRepository;
   private final MemberRepository memberRepository;
@@ -36,7 +39,6 @@ public class NotificationServiceImpl implements NotificationService {
   public List<NotificationDto> getNotifications(Long memberId) {
     MemberEntity member = memberRepository.findById(memberId)
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
-    //TODO : 알림을 모두 읽음 처리 (세션 변경)
 
     List<NotificationEntity> notificationList =
         notificationRepository.findByMemberOrderByCreatedAtDesc(member);
@@ -73,6 +75,13 @@ public class NotificationServiceImpl implements NotificationService {
 
     return NotificationDto.fromEntity(saved);
   }
+
+  @Override
+  public void setUnreadNotificationSession(HttpServletRequest httpServletRequest, boolean isUnread) {
+    HttpSession session = httpServletRequest.getSession();
+    session.setAttribute(UNREAD_NOTIFICATION, isUnread);
+  }
+
 
   /**
    * 클라이언트에게 데이터 전송

--- a/src/main/java/com/anonymous/usports/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/notification/service/impl/NotificationServiceImpl.java
@@ -78,8 +78,20 @@ public class NotificationServiceImpl implements NotificationService {
 
   @Override
   public void setUnreadNotificationSession(HttpServletRequest httpServletRequest, boolean isUnread) {
-    HttpSession session = httpServletRequest.getSession();
+    HttpSession session = httpServletRequest.getSession(); // 세션이 없으면 세션 생성
     session.setAttribute(UNREAD_NOTIFICATION, isUnread);
+  }
+
+  @Override
+  public void checkUnreadNotificationAndSetSession(Long memberId,
+      HttpServletRequest httpServletRequest) {
+    MemberEntity member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+    boolean result = notificationRepository.existsByMemberAndReadAtIsNull(member);
+
+    HttpSession session = httpServletRequest.getSession(); // 세션이 없으면 세션 생성
+    session.setAttribute(UNREAD_NOTIFICATION, result);
   }
 
 

--- a/src/main/java/com/anonymous/usports/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/notification/service/impl/NotificationServiceImpl.java
@@ -43,7 +43,7 @@ public class NotificationServiceImpl implements NotificationService {
     List<NotificationEntity> notificationList =
         notificationRepository.findByMemberOrderByCreatedAtDesc(member);
 
-    for(NotificationEntity n : notificationList){
+    for (NotificationEntity n : notificationList) {
       n.readNow();
     }
     List<NotificationEntity> saved = notificationRepository.saveAll(
@@ -77,13 +77,14 @@ public class NotificationServiceImpl implements NotificationService {
   }
 
   @Override
-  public void setUnreadNotificationSession(HttpServletRequest httpServletRequest, boolean isUnread) {
+  public void setUnreadNotificationSession(HttpServletRequest httpServletRequest,
+      boolean isUnread) {
     HttpSession session = httpServletRequest.getSession(); // 세션이 없으면 세션 생성
     session.setAttribute(UNREAD_NOTIFICATION, isUnread);
   }
 
   @Override
-  public void checkUnreadNotificationAndSetSession(Long memberId,
+  public boolean checkUnreadNotificationAndSetSession(Long memberId,
       HttpServletRequest httpServletRequest) {
     MemberEntity member = memberRepository.findById(memberId)
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
@@ -92,6 +93,8 @@ public class NotificationServiceImpl implements NotificationService {
 
     HttpSession session = httpServletRequest.getSession(); // 세션이 없으면 세션 생성
     session.setAttribute(UNREAD_NOTIFICATION, result);
+
+    return result;
   }
 
 

--- a/src/test/java/com/anonymous/usports/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/notification/service/NotificationServiceTest.java
@@ -267,6 +267,8 @@ class NotificationServiceTest {
           catchThrowableOfType(() ->
               notificationService
                   .checkUnreadNotificationAndSetSession(1L, httpServletRequest), MemberException.class);
+
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
     }
 
   }


### PR DESCRIPTION
### 변경사항
**[세션을 사용하여 안읽은 알림 존재 여부를 확인할 수 있도록 함]**
- 회원 로그인 시 세션에 `unreadNotification` 여부를 담아줌.
- 알림 발생 시 sse 전송과 함께 `unreadNotification=true`로 변경
- 알림 리스트 조회 페이지 이동 시 `unreadNotification=false`로 변경

**[테스트 방법]**
- 안 읽은 알림 있을 때 :  unreadNotification=true
- 안 읽은 알림 없을 때 :  unreadNotification=false
- 테스트용으로 여러가지 수정해놓고, FIXME를 달아놨음.
- API 테스트 완료
  - "/send/id"로 알림 생성 후 "/test" 호출하여 확인
  - "/notifications"로 알림 조회 후 "/test" 호출하여 확인 

**[테스트 코드 작성]**
- getNotifications() : 알림 리스트 조회
- notify() : 알림 등록, sse 전송
- checkUnreadNotificationAndSetSession() : 로그인 시 안읽은 알림 존재 여부 확인  

(고민)
- 나머지 메서드는 어떻게 테스트 해야할지 모르겠음..

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드 ..미완
- [x] API 테스트 
