### PR TITLE
Feature/mypage

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/controller/MyPageController.java
@@ -1,0 +1,25 @@
+package com.anonymous.usports.domain.mypage.controller;
+
+import com.anonymous.usports.domain.member.dto.MemberDto;
+import com.anonymous.usports.domain.mypage.dto.MyPageMainDto;
+import com.anonymous.usports.domain.mypage.service.MyPageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class MyPageController {
+
+  private final MyPageService myPageService;
+
+  @GetMapping("/mypage")
+  public ResponseEntity<MyPageMainDto> myPage(@AuthenticationPrincipal MemberDto loginMember){
+    MyPageMainDto myPageMainData = myPageService.getMyPageMainData(loginMember.getMemberId());
+    return ResponseEntity.ok(myPageMainData);
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageMainDto.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageMainDto.java
@@ -1,0 +1,22 @@
+package com.anonymous.usports.domain.mypage.dto;
+
+import com.anonymous.usports.domain.sportsskill.dto.SportsSkillDto;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MyPageMainDto {
+
+  private MyPageMember member;
+
+  private List<SportsSkillDto> sportsSkills;
+
+}

--- a/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageMainDto.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageMainDto.java
@@ -26,6 +26,4 @@ public class MyPageMainDto {
 
   private List<MyPageRecruit> myRecruitList;//내 모집 관리
 
-  private MemberDto memberEdit;//내 정보 수정
-
 }

--- a/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageMainDto.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageMainDto.java
@@ -19,4 +19,6 @@ public class MyPageMainDto {
 
   private List<SportsSkillDto> sportsSkills;
 
+  private List<RecruitAndParticipants> recruitAndParticipants;
+
 }

--- a/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageMainDto.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageMainDto.java
@@ -21,4 +21,6 @@ public class MyPageMainDto {
 
   private List<RecruitAndParticipants> recruitAndParticipants;
 
+  private List<MyPageParticipant> participantList;
+
 }

--- a/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageMainDto.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageMainDto.java
@@ -16,16 +16,16 @@ import lombok.Setter;
 @Builder
 public class MyPageMainDto {
 
-  private MyPageMember memberProfile;
+  private MyPageMember memberProfile;//회원 정보
 
-  private List<SportsSkillDto> sportsSkills;
+  private List<SportsSkillDto> sportsSkills;//팝업으로 띄워줄 sportSkill
 
-  private List<RecruitAndParticipants> recruitAndParticipants;
+  private List<RecruitAndParticipants> recruitAndParticipants;//평가하기
 
-  private List<MyPageParticipant> participantList;
+  private List<MyPageParticipant> participateList;//내 신청 현황
 
-  private List<MyPageRecruit> myRecruitList;
+  private List<MyPageRecruit> myRecruitList;//내 모집 관리
 
-  private MemberDto memberEdit;
+  private MemberDto memberEdit;//내 정보 수정
 
 }

--- a/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageMainDto.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageMainDto.java
@@ -1,5 +1,6 @@
 package com.anonymous.usports.domain.mypage.dto;
 
+import com.anonymous.usports.domain.member.dto.MemberDto;
 import com.anonymous.usports.domain.sportsskill.dto.SportsSkillDto;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -15,12 +16,16 @@ import lombok.Setter;
 @Builder
 public class MyPageMainDto {
 
-  private MyPageMember member;
+  private MyPageMember memberProfile;
 
   private List<SportsSkillDto> sportsSkills;
 
   private List<RecruitAndParticipants> recruitAndParticipants;
 
   private List<MyPageParticipant> participantList;
+
+  private List<MyPageRecruit> myRecruitList;
+
+  private MemberDto memberEdit;
 
 }

--- a/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageMember.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageMember.java
@@ -1,0 +1,44 @@
+package com.anonymous.usports.domain.mypage.dto;
+
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MyPageMember {
+
+  private String profileImage;
+
+  private Long memberId;
+
+  private String name;
+  private String accountName;
+  private String email;
+
+  private List<String> interestSportsList;
+  private int plusAlpha;
+
+  private Double mannerScore;
+
+
+  public MyPageMember(MemberEntity memberEntity, List<String> interestSportsList, int plusAlpha){
+    this.profileImage = memberEntity.getProfileImage();
+    this.memberId = memberEntity.getMemberId();
+    this.name = memberEntity.getName();
+    this.accountName = memberEntity.getAccountName();
+    this.email = memberEntity.getEmail();
+    this.interestSportsList = interestSportsList;
+    this.plusAlpha = plusAlpha;
+    this.mannerScore = memberEntity.getMannerScore();
+  }
+
+}

--- a/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageParticipant.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageParticipant.java
@@ -1,0 +1,22 @@
+package com.anonymous.usports.domain.mypage.dto;
+
+import com.anonymous.usports.global.type.ParticipantStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MyPageParticipant {
+
+  private String sportsName;
+  private String recruitTile;
+  private ParticipantStatus status;
+
+}

--- a/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageRecruit.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/dto/MyPageRecruit.java
@@ -1,0 +1,36 @@
+package com.anonymous.usports.domain.mypage.dto;
+
+import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
+import com.anonymous.usports.global.type.Gender;
+import com.anonymous.usports.global.type.RecruitStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MyPageRecruit {
+
+  private Long recruitId;
+
+  private String sportsName;
+
+  private String title;
+
+  private Gender gender;
+
+  private RecruitStatus status;
+
+  public MyPageRecruit(RecruitEntity recruit) {
+    this.recruitId =  recruit.getRecruitId();
+    this.sportsName = recruit.getSports().getSportsName();
+    this.title = recruit.getTitle();
+    this.gender =recruit.getGender();
+    this.status =  recruit.getRecruitStatus();
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/mypage/dto/RecruitAndParticipants.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/dto/RecruitAndParticipants.java
@@ -14,11 +14,11 @@ import lombok.Setter;
 @Builder
 public class RecruitAndParticipants {
 
-  private RecruitDto recruitDto;
+  private RecruitDto recruit;
   private List<MemberDto> memberList;
 
-  public RecruitAndParticipants(RecruitDto recruitDto, List<MemberDto> memberList) {
-    this.recruitDto = recruitDto;
+  public RecruitAndParticipants(RecruitDto recruit, List<MemberDto> memberList) {
+    this.recruit = recruit;
     this.memberList = memberList;
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/mypage/dto/RecruitAndParticipants.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/dto/RecruitAndParticipants.java
@@ -1,0 +1,24 @@
+package com.anonymous.usports.domain.mypage.dto;
+
+import com.anonymous.usports.domain.member.dto.MemberDto;
+import com.anonymous.usports.domain.recruit.dto.RecruitDto;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Builder
+public class RecruitAndParticipants {
+
+  private RecruitDto recruitDto;
+  private List<MemberDto> memberList;
+
+  public RecruitAndParticipants(RecruitDto recruitDto, List<MemberDto> memberList) {
+    this.recruitDto = recruitDto;
+    this.memberList = memberList;
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/service/MyPageService.java
@@ -1,0 +1,8 @@
+package com.anonymous.usports.domain.mypage.service;
+
+import com.anonymous.usports.domain.mypage.dto.MyPageMainDto;
+
+public interface MyPageService {
+
+  MyPageMainDto getMyPageMainData(Long memberId);
+}

--- a/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
@@ -20,9 +20,7 @@ import com.anonymous.usports.domain.sportsskill.dto.SportsSkillDto;
 import com.anonymous.usports.domain.sportsskill.repository.SportsSkillRepository;
 import com.anonymous.usports.global.exception.ErrorCode;
 import com.anonymous.usports.global.exception.MemberException;
-import com.anonymous.usports.global.type.Gender;
 import com.anonymous.usports.global.type.ParticipantStatus;
-import com.anonymous.usports.global.type.RecruitStatus;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -67,8 +65,16 @@ public class MyPageServiceImpl implements MyPageService {
     List<MyPageRecruit> myRecruitList = this.getMyRecruitList(member);
 
     //내 정보 수정
+    MemberDto memberEdit = MemberDto.fromEntity(member);
 
-    return null;
+    return MyPageMainDto.builder()
+        .memberProfile(myPageMember)
+        .sportsSkills(sportsSkills)
+        .recruitAndParticipants(recruitAndParticipants)
+        .participantList(participantList)
+        .myRecruitList(myRecruitList)
+        .memberEdit(memberEdit)
+        .build();
   }
 
   public MyPageMember getMyPageMember(MemberEntity member) {
@@ -161,7 +167,7 @@ public class MyPageServiceImpl implements MyPageService {
     return list;
   }
 
-  public List<MyPageRecruit> getMyRecruitList(MemberEntity member){
+  public List<MyPageRecruit> getMyRecruitList(MemberEntity member) {
     List<RecruitEntity> findList =
         recruitRepository.findTop10ByMemberAndOrderByMeetingDateDesc(member);
 

--- a/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
@@ -7,6 +7,7 @@ import com.anonymous.usports.domain.member.repository.InterestedSportsRepository
 import com.anonymous.usports.domain.member.repository.MemberRepository;
 import com.anonymous.usports.domain.mypage.dto.MyPageMainDto;
 import com.anonymous.usports.domain.mypage.dto.MyPageMember;
+import com.anonymous.usports.domain.mypage.dto.MyPageParticipant;
 import com.anonymous.usports.domain.mypage.dto.RecruitAndParticipants;
 import com.anonymous.usports.domain.mypage.service.MyPageService;
 import com.anonymous.usports.domain.participant.entity.ParticipantEntity;
@@ -55,6 +56,7 @@ public class MyPageServiceImpl implements MyPageService {
     List<RecruitAndParticipants> recruitAndParticipants = this.getRecruitAndParticipants(member);
 
     //내 신청 현황 : 내가 신청한 참여신청(Participant) 리스트
+    List<MyPageParticipant> participantList = this.getParticipantList(member);
 
     //내 모집 관리 : 내가 만든 모집 관리
 
@@ -133,5 +135,25 @@ public class MyPageServiceImpl implements MyPageService {
     }
     return recruitAndParticipants;
   }
+
+  public List<MyPageParticipant> getParticipantList(MemberEntity member) {
+    List<MyPageParticipant> list = new ArrayList<>();
+
+    for (ParticipantEntity participant :
+        participantRepository.findTop10ByMemberOrderByRegisteredAtDesc(member)) {
+
+      RecruitEntity recruit = participant.getRecruit();
+
+      list.add(
+          new MyPageParticipant(
+              recruit.getSports().getSportsName(),
+              recruit.getTitle(),
+              participant.getStatus())
+      );
+    }
+
+    return list;
+  }
+
 
 }

--- a/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
@@ -71,7 +71,7 @@ public class MyPageServiceImpl implements MyPageService {
         .memberProfile(myPageMember)
         .sportsSkills(sportsSkills)
         .recruitAndParticipants(recruitAndParticipants)
-        .participantList(participantList)
+        .participateList(participantList)
         .myRecruitList(myRecruitList)
         .memberEdit(memberEdit)
         .build();
@@ -169,7 +169,7 @@ public class MyPageServiceImpl implements MyPageService {
 
   public List<MyPageRecruit> getMyRecruitList(MemberEntity member) {
     List<RecruitEntity> findList =
-        recruitRepository.findTop10ByMemberAndOrderByMeetingDateDesc(member);
+        recruitRepository.findTop10ByMemberOrderByMeetingDateDesc(member);
 
     List<MyPageRecruit> list = new ArrayList<>();
     for (RecruitEntity recruit : findList) {

--- a/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
@@ -8,6 +8,7 @@ import com.anonymous.usports.domain.member.repository.MemberRepository;
 import com.anonymous.usports.domain.mypage.dto.MyPageMainDto;
 import com.anonymous.usports.domain.mypage.dto.MyPageMember;
 import com.anonymous.usports.domain.mypage.dto.MyPageParticipant;
+import com.anonymous.usports.domain.mypage.dto.MyPageRecruit;
 import com.anonymous.usports.domain.mypage.dto.RecruitAndParticipants;
 import com.anonymous.usports.domain.mypage.service.MyPageService;
 import com.anonymous.usports.domain.participant.entity.ParticipantEntity;
@@ -19,7 +20,9 @@ import com.anonymous.usports.domain.sportsskill.dto.SportsSkillDto;
 import com.anonymous.usports.domain.sportsskill.repository.SportsSkillRepository;
 import com.anonymous.usports.global.exception.ErrorCode;
 import com.anonymous.usports.global.exception.MemberException;
+import com.anonymous.usports.global.type.Gender;
 import com.anonymous.usports.global.type.ParticipantStatus;
+import com.anonymous.usports.global.type.RecruitStatus;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +32,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -42,6 +46,7 @@ public class MyPageServiceImpl implements MyPageService {
   private final ParticipantRepository participantRepository;
 
   @Override
+  @Transactional
   public MyPageMainDto getMyPageMainData(Long memberId) {
     MemberEntity member = memberRepository.findById(memberId)
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
@@ -59,6 +64,7 @@ public class MyPageServiceImpl implements MyPageService {
     List<MyPageParticipant> participantList = this.getParticipantList(member);
 
     //내 모집 관리 : 내가 만든 모집 관리
+    List<MyPageRecruit> myRecruitList = this.getMyRecruitList(member);
 
     //내 정보 수정
 
@@ -152,6 +158,17 @@ public class MyPageServiceImpl implements MyPageService {
       );
     }
 
+    return list;
+  }
+
+  public List<MyPageRecruit> getMyRecruitList(MemberEntity member){
+    List<RecruitEntity> findList =
+        recruitRepository.findTop10ByMemberAndOrderByMeetingDateDesc(member);
+
+    List<MyPageRecruit> list = new ArrayList<>();
+    for (RecruitEntity recruit : findList) {
+      list.add(new MyPageRecruit(recruit));
+    }
     return list;
   }
 

--- a/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
@@ -119,15 +119,15 @@ public class MyPageServiceImpl implements MyPageService {
 
   public List<RecruitAndParticipants> getRecruitAndParticipants(MemberEntity member) {
     //끝난지 48시간 이내의 참여 신청 건
-    List<ParticipantEntity> findList = participantRepository
+    List<ParticipantEntity> thisMemberParticipateList = participantRepository
         .findAllByMemberAndMeetingDateIsAfter(member, LocalDateTime.now().minusDays(2L));
-    if (findList.isEmpty()) {
+    if (thisMemberParticipateList.isEmpty()) {
       return new ArrayList<>();
     }
 
     List<RecruitAndParticipants> recruitAndParticipants = new ArrayList<>();
 
-    for (ParticipantEntity loginMemberParticipate : findList) {
+    for (ParticipantEntity loginMemberParticipate : thisMemberParticipateList) {
       RecruitEntity recruit = loginMemberParticipate.getRecruit();
 
       List<ParticipantEntity> otherParticipants =

--- a/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
@@ -1,0 +1,88 @@
+package com.anonymous.usports.domain.mypage.service.impl;
+
+import com.anonymous.usports.domain.member.entity.InterestedSportsEntity;
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.member.repository.InterestedSportsRepository;
+import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.domain.mypage.dto.MyPageMainDto;
+import com.anonymous.usports.domain.mypage.dto.MyPageMember;
+import com.anonymous.usports.domain.mypage.service.MyPageService;
+import com.anonymous.usports.domain.sportsskill.dto.SportsSkillDto;
+import com.anonymous.usports.domain.sportsskill.repository.SportsSkillRepository;
+import com.anonymous.usports.global.exception.ErrorCode;
+import com.anonymous.usports.global.exception.MemberException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MyPageServiceImpl implements MyPageService {
+
+  private final MemberRepository memberRepository;
+  private final InterestedSportsRepository interestedSportsRepository;
+  private final SportsSkillRepository sportsSkillRepository;
+
+  @Override
+  public MyPageMainDto getMyPageMainData(Long memberId) {
+    MemberEntity member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+    //회원 정보
+    MyPageMember myPageMember = this.getMyPageMember(member);
+    //팝업으로 띄워줄 sportSkill
+    List<SportsSkillDto> sportsSkills = this.getSportsSkills(member);
+    //평가를 하기 위한 내가 참여했던 Recruit와 참여자 리스트 - RecruitAndParticipants
+    //내 신청 현황
+    //내가 만든 모집 관리
+    //내 정보 수정
+
+    return null;
+  }
+
+  public MyPageMember getMyPageMember(MemberEntity member) {
+    List<InterestedSportsEntity> interestedSportsEntityList =
+        interestedSportsRepository.findAllByMemberEntity(member);
+    int listSize = interestedSportsEntityList.size();
+
+    List<String> interestSportsList = new ArrayList<>();
+
+    if (listSize == 0) {
+      interestSportsList.add("none");
+      return new MyPageMember(member, interestSportsList, 0);
+    }
+
+    int plusAlpha = 0;
+    if (listSize > 3) {
+      plusAlpha = listSize - 3;
+      Random random = new Random();
+      for (int i = 0; i < 3; i++) {
+        interestSportsList.add(
+            interestedSportsEntityList
+                .get(random.nextInt(listSize))
+                .getSports()
+                .getSportsName());
+      }
+
+    } else {
+      for (InterestedSportsEntity interestedSports : interestedSportsEntityList) {
+        interestSportsList.add(interestedSports.getSports().getSportsName());
+      }
+    }
+
+    return new MyPageMember(member, interestSportsList, plusAlpha);
+  }
+
+  public List<SportsSkillDto> getSportsSkills(MemberEntity member) {
+    return sportsSkillRepository.findAllByMember(member)
+        .stream()
+        .map(SportsSkillDto::new)
+        .collect(Collectors.toList());
+  }
+
+}

--- a/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
@@ -64,8 +64,6 @@ public class MyPageServiceImpl implements MyPageService {
     //내 모집 관리 : 내가 만든 모집 관리
     List<MyPageRecruit> myRecruitList = this.getMyRecruitList(member);
 
-    //내 정보 수정
-    MemberDto memberEdit = MemberDto.fromEntity(member);
 
     return MyPageMainDto.builder()
         .memberProfile(myPageMember)
@@ -73,7 +71,6 @@ public class MyPageServiceImpl implements MyPageService {
         .recruitAndParticipants(recruitAndParticipants)
         .participateList(participantList)
         .myRecruitList(myRecruitList)
-        .memberEdit(memberEdit)
         .build();
   }
 

--- a/src/main/java/com/anonymous/usports/domain/participant/dto/ParticipantDto.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/dto/ParticipantDto.java
@@ -30,6 +30,8 @@ public class ParticipantDto {
 
   private LocalDateTime evaluationAt; //타인 평가 일시
 
+  private LocalDateTime meetingDate; //Recruit의 모임 일시
+
   public static ParticipantDto fromEntity(ParticipantEntity participant){
     return ParticipantDto.builder()
         .participantId(participant.getParticipantId())
@@ -39,6 +41,7 @@ public class ParticipantDto {
         .confirmedAt(participant.getConfirmedAt())
         .status(participant.getStatus())
         .evaluationAt(participant.getEvaluationAt())
+        .meetingDate(participant.getMeetingDate())
         .build();
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/participant/entity/ParticipantEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/entity/ParticipantEntity.java
@@ -61,10 +61,14 @@ public class ParticipantEntity {
   @Column(name = "evaluation_at")
   private LocalDateTime evaluationAt; //타인 평가 일시
 
+  @Column(name = "meeting_date")
+  private LocalDateTime meetingDate;
+
   public ParticipantEntity(MemberEntity member, RecruitEntity recruit) {
     this.member = member;
     this.recruit = recruit;
     this.status = ParticipantStatus.ING;
+    this.meetingDate = recruit.getMeetingDate();
   }
 
   public void confirm() {

--- a/src/main/java/com/anonymous/usports/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/repository/ParticipantRepository.java
@@ -4,6 +4,8 @@ import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.participant.entity.ParticipantEntity;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.global.type.ParticipantStatus;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,8 +14,19 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ParticipantRepository extends JpaRepository<ParticipantEntity, Long> {
-  Optional<ParticipantEntity> findByMemberAndRecruitAndStatus(MemberEntity member, RecruitEntity recruit, ParticipantStatus status);
+
+  Optional<ParticipantEntity> findByMemberAndRecruitAndStatus(MemberEntity member,
+      RecruitEntity recruit, ParticipantStatus status);
+
   Optional<ParticipantEntity> findByMemberAndRecruit(MemberEntity member, RecruitEntity recruit);
-  Page<ParticipantEntity> findAllByRecruitAndStatusOrderByParticipantId(RecruitEntity recruit, ParticipantStatus status, Pageable pageable);
+
+  Page<ParticipantEntity> findAllByRecruitAndStatusOrderByParticipantId(RecruitEntity recruit,
+      ParticipantStatus status, Pageable pageable);
+
   void deleteAllByRecruit(RecruitEntity recruit);
+
+  List<ParticipantEntity> findAllByMemberAndMeetingDateIsAfter(MemberEntity member,
+      LocalDateTime datetime);
+
+  List<ParticipantEntity> findAllByRecruitAndStatus(RecruitEntity recruit, ParticipantStatus status);
 }

--- a/src/main/java/com/anonymous/usports/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/repository/ParticipantRepository.java
@@ -29,4 +29,6 @@ public interface ParticipantRepository extends JpaRepository<ParticipantEntity, 
       LocalDateTime datetime);
 
   List<ParticipantEntity> findAllByRecruitAndStatus(RecruitEntity recruit, ParticipantStatus status);
+
+  List<ParticipantEntity> findTop10ByMemberOrderByRegisteredAtDesc(MemberEntity member);
 }

--- a/src/main/java/com/anonymous/usports/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/repository/RecruitRepository.java
@@ -1,8 +1,11 @@
 package com.anonymous.usports.domain.recruit.repository;
 
+import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.domain.sports.entity.SportsEntity;
 import com.anonymous.usports.global.type.Gender;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -39,4 +42,5 @@ public interface RecruitRepository extends JpaRepository<RecruitEntity, Long>{
       @Param("gender") Gender gender,
       Pageable pageable);
 
+  List<RecruitEntity> findTop10ByMemberAndOrderByMeetingDateDesc(MemberEntity member);
 }

--- a/src/main/java/com/anonymous/usports/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/repository/RecruitRepository.java
@@ -4,7 +4,6 @@ import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.domain.sports.entity.SportsEntity;
 import com.anonymous.usports.global.type.Gender;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -42,5 +41,5 @@ public interface RecruitRepository extends JpaRepository<RecruitEntity, Long>{
       @Param("gender") Gender gender,
       Pageable pageable);
 
-  List<RecruitEntity> findTop10ByMemberAndOrderByMeetingDateDesc(MemberEntity member);
+  List<RecruitEntity> findTop10ByMemberOrderByMeetingDateDesc(MemberEntity member);
 }

--- a/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
@@ -2,6 +2,7 @@ package com.anonymous.usports.domain.recruit.service.impl;
 
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.domain.participant.entity.ParticipantEntity;
 import com.anonymous.usports.domain.participant.repository.ParticipantRepository;
 import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
@@ -21,8 +22,10 @@ import com.anonymous.usports.global.exception.MyException;
 import com.anonymous.usports.global.exception.RecruitException;
 import com.anonymous.usports.global.exception.SportsException;
 import com.anonymous.usports.global.type.Gender;
+import com.anonymous.usports.global.type.ParticipantStatus;
 import com.anonymous.usports.global.type.RecruitStatus;
 import io.jsonwebtoken.lang.Strings;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -131,9 +134,14 @@ public class RecruitServiceImpl implements RecruitService {
     }
 
     //RECRUITING or ALMOST_FINISHED-> 모집 마감 상태로 변경
+    //ING 상태의 Participants 모두 거절
+    List<ParticipantEntity> participants =
+        participantRepository.findAllByRecruitAndStatus(recruitEntity, ParticipantStatus.ING);
+    for (ParticipantEntity participant : participants) {
+      participant.refuse();
+    }
     recruitEntity.statusToEnd();
     return new RecruitEndResponse(recruitId, ResponseConstant.END_RECRUIT_COMPLETE);
-
   }
 
   @Override

--- a/src/main/java/com/anonymous/usports/domain/sportsskill/dto/SportsSkillDto.java
+++ b/src/main/java/com/anonymous/usports/domain/sportsskill/dto/SportsSkillDto.java
@@ -1,0 +1,32 @@
+package com.anonymous.usports.domain.sportsskill.dto;
+
+import com.anonymous.usports.domain.sports.entity.SportsEntity;
+import com.anonymous.usports.domain.sportsskill.entity.SportsSkillEntity;
+import com.anonymous.usports.global.type.SportsGrade;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SportsSkillDto {
+  private Long sportsSkillId;
+  private String sportsName;
+  private SportsGrade sportsGrade;
+
+  public SportsSkillDto(SportsSkillEntity sportsSkillEntity){
+    this.sportsSkillId = sportsSkillEntity.getSports().getSportsId();
+    this.sportsName = sportsSkillEntity.getSports().getSportsName();
+
+    double score =
+        (double) sportsSkillEntity.getSportsScore() / sportsSkillEntity.getEvaluateCount();
+    this.sportsGrade = SportsGrade.doubleToGrade(score);
+  }
+
+
+}

--- a/src/main/java/com/anonymous/usports/domain/sportsskill/repository/SportsSkillRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/sportsskill/repository/SportsSkillRepository.java
@@ -3,6 +3,7 @@ package com.anonymous.usports.domain.sportsskill.repository;
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.sports.entity.SportsEntity;
 import com.anonymous.usports.domain.sportsskill.entity.SportsSkillEntity;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,5 +11,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SportsSkillRepository extends JpaRepository<SportsSkillEntity, Long> {
   Optional<SportsSkillEntity> findByMemberAndSports(MemberEntity member, SportsEntity sports);
+  List<SportsSkillEntity> findAllByMember(MemberEntity member);
 
 }

--- a/src/main/java/com/anonymous/usports/global/type/SportsGrade.java
+++ b/src/main/java/com/anonymous/usports/global/type/SportsGrade.java
@@ -1,0 +1,56 @@
+package com.anonymous.usports.global.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@AllArgsConstructor
+@Getter
+public enum SportsGrade {
+  ROOKIE(1, "Rookie", "루키"),
+  BEGINNER_1(2, "Beginner 1", "비기너 1"),
+  BEGINNER_2(3, "Beginner 2", "비기너 2"),
+  BEGINNER_3(4, "Beginner 3", "비기너 3"),
+  AMATEUR_1(5, "Amateur 1", "아마추어 1"),
+  AMATEUR_2(6, "Amateur 2", "아마추어 2"),
+  AMATEUR_3(7, "Amateur 3", "아마추어 3"),
+  SEMI_PRO_1(8, "Semi-pro 1", "세미프로 1"),
+  SEMI_PRO_2(9, "Semi-pro 2", "세미프로 2"),
+  PRO(10, "Professional", "프로");
+
+  private final int score;
+  private final String en;
+  private final String kr;
+
+  public static SportsGrade doubleToGrade(double score){
+
+    if(score >= 0 && score <= 1){
+      return ROOKIE;
+    }else if(score > 1 && score <= 2){
+      return BEGINNER_1;
+    }else if(score > 2 && score <= 3){
+      return BEGINNER_2;
+    }else if(score > 3 && score <= 4){
+      return BEGINNER_3;
+    }else if(score > 4 && score <= 5){
+      return AMATEUR_1;
+    }else if(score > 5 && score <= 6){
+      return AMATEUR_2;
+    }else if(score > 6 && score <= 7){
+      return AMATEUR_3;
+    }else if(score > 7 && score <= 8){
+      return SEMI_PRO_1;
+    }else if(score > 8 && score <= 9){
+      return SEMI_PRO_2;
+    }else if(score > 9 && score <= 10){
+      return PRO;
+    }
+
+    if(score > 10){
+      log.error("SportsGrade over 10!!!");
+      return PRO;
+    }
+    return ROOKIE;
+  }
+}

--- a/src/test/java/com/anonymous/usports/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/mypage/service/MyPageServiceTest.java
@@ -1,0 +1,343 @@
+package com.anonymous.usports.domain.mypage.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.when;
+
+import com.anonymous.usports.domain.member.entity.InterestedSportsEntity;
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.member.repository.InterestedSportsRepository;
+import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.domain.mypage.dto.MyPageMember;
+import com.anonymous.usports.domain.mypage.dto.MyPageParticipant;
+import com.anonymous.usports.domain.mypage.dto.MyPageRecruit;
+import com.anonymous.usports.domain.mypage.service.impl.MyPageServiceImpl;
+import com.anonymous.usports.domain.participant.entity.ParticipantEntity;
+import com.anonymous.usports.domain.participant.repository.ParticipantRepository;
+import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
+import com.anonymous.usports.domain.recruit.repository.RecruitRepository;
+import com.anonymous.usports.domain.sports.entity.SportsEntity;
+import com.anonymous.usports.domain.sportsskill.dto.SportsSkillDto;
+import com.anonymous.usports.domain.sportsskill.entity.SportsSkillEntity;
+import com.anonymous.usports.domain.sportsskill.repository.SportsSkillRepository;
+import com.anonymous.usports.global.type.Gender;
+import com.anonymous.usports.global.type.ParticipantStatus;
+import com.anonymous.usports.global.type.RecruitStatus;
+import com.anonymous.usports.global.type.Role;
+import com.anonymous.usports.global.type.SportsGrade;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class MyPageServiceTest {
+
+  @Mock
+  private InterestedSportsRepository interestedSportsRepository;
+  @Mock
+  private SportsSkillRepository sportsSkillRepository;
+  @Mock
+  private RecruitRepository recruitRepository;
+  @Mock
+  private ParticipantRepository participantRepository;
+
+
+  @InjectMocks
+  private MyPageServiceImpl myPageService;
+
+  private MemberEntity createMember(Long id) {
+    return MemberEntity.builder()
+        .memberId(id)
+        .accountName("accountName" + id)
+        .name("name" + id)
+        .email("test@test.com")
+        .password("password" + id)
+        .phoneNumber("010-1111-2222")
+        .birthDate(LocalDate.now())
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .profileOpen(true)
+        .build();
+  }
+
+  private SportsEntity createSports(Long id) {
+    return new SportsEntity(id, "football");
+  }
+
+  private RecruitEntity createRecruit(Long id, MemberEntity member, SportsEntity sports) {
+    return RecruitEntity.builder()
+        .recruitId(id)
+        .sports(sports)
+        .member(member)
+        .title("title" + id)
+        .content("content" + id)
+        .placeName("placeName" + id)
+        .lat("111")
+        .lnt("100")
+        .cost(10000)
+        .gender(Gender.MALE)
+        .currentCount(1)
+        .recruitCount(10)
+        .meetingDate(LocalDateTime.now())
+        .recruitStatus(RecruitStatus.RECRUITING)
+        .registeredAt(LocalDateTime.now())
+        .gradeFrom(1)
+        .gradeTo(10)
+        .build();
+  }
+
+  private ParticipantEntity createParticipant(Long id, MemberEntity member, RecruitEntity recruit) {
+    return ParticipantEntity.builder()
+        .participantId(id)
+        .member(member)
+        .recruit(recruit)
+        .registeredAt(LocalDateTime.now().minusDays(3L))
+        .meetingDate(LocalDateTime.now().minusDays(1L))
+        .status(ParticipantStatus.ACCEPTED)
+        .build();
+  }
+
+
+  @Nested
+  @DisplayName("MyPage member 데이터")
+  class GetMyPageMember {
+
+    private InterestedSportsEntity createInterestSports(Long id, MemberEntity member,
+        SportsEntity sports) {
+      return InterestedSportsEntity.builder()
+          .interestedSportsId(id)
+          .memberEntity(member)
+          .sports(sports)
+          .build();
+    }
+
+    @Test
+    @DisplayName("성공 : 관심운동 5개")
+    void getMyPageMember_5() {
+      MemberEntity member = createMember(1L);
+      List<InterestedSportsEntity> interestedSportsEntityList = new ArrayList<>();
+      for (int i = 0; i < 5; i++) {
+        interestedSportsEntityList.add(
+            createInterestSports(10L + i, member, createSports(100L + i)));
+      }
+      //given
+      when(interestedSportsRepository.findAllByMemberEntity(member))
+          .thenReturn(interestedSportsEntityList);
+
+      //when
+      MyPageMember myPageMember = myPageService.getMyPageMember(member);
+
+      //then
+      assertThat(myPageMember.getInterestSportsList().size()).isEqualTo(3);
+      assertThat(myPageMember.getPlusAlpha()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("성공 : 관심운동 3개")
+    void getMyPageMember_3() {
+      MemberEntity member = createMember(1L);
+      List<InterestedSportsEntity> interestedSportsEntityList = new ArrayList<>();
+      for (int i = 0; i < 3; i++) {
+        interestedSportsEntityList.add(
+            createInterestSports(10L + i, member, createSports(100L + i)));
+      }
+      //given
+      when(interestedSportsRepository.findAllByMemberEntity(member))
+          .thenReturn(interestedSportsEntityList);
+
+      //when
+      MyPageMember myPageMember = myPageService.getMyPageMember(member);
+
+      //then
+      assertThat(myPageMember.getInterestSportsList().size()).isEqualTo(3);
+      assertThat(myPageMember.getPlusAlpha()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("성공 : 관심운동 1개")
+    void getMyPageMember() {
+      MemberEntity member = createMember(1L);
+      List<InterestedSportsEntity> interestedSportsEntityList = new ArrayList<>();
+      for (int i = 0; i < 1; i++) {
+        interestedSportsEntityList.add(
+            createInterestSports(10L + i, member, createSports(100L + i)));
+      }
+      //given
+      when(interestedSportsRepository.findAllByMemberEntity(member))
+          .thenReturn(interestedSportsEntityList);
+
+      //when
+      MyPageMember myPageMember = myPageService.getMyPageMember(member);
+
+      //then
+      assertThat(myPageMember.getInterestSportsList().size()).isEqualTo(1);
+      assertThat(myPageMember.getPlusAlpha()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("성공 : 관심운동 0개")
+    void getMyPageMember_0() {
+      MemberEntity member = createMember(1L);
+      List<InterestedSportsEntity> interestedSportsEntityList = new ArrayList<>();
+
+      //given
+      when(interestedSportsRepository.findAllByMemberEntity(member))
+          .thenReturn(interestedSportsEntityList);
+
+      //when
+      MyPageMember myPageMember = myPageService.getMyPageMember(member);
+
+      //then
+      assertThat(myPageMember.getInterestSportsList().get(0)).isEqualTo("none");
+      assertThat(myPageMember.getPlusAlpha()).isEqualTo(0);
+    }
+  }
+
+  private SportsSkillEntity createSportsSkill(Long id, MemberEntity member, SportsEntity sports) {
+    return SportsSkillEntity.builder()
+        .sportsSkillId(id)
+        .member(member)
+        .sports(sports)
+        .sportsScore(15L)
+        .evaluateCount(3)
+        .build();
+  }
+
+  @Test
+  @DisplayName("SportsSkills")
+  void getSportsSkills() {
+    MemberEntity member = createMember(1L);
+    List<SportsSkillEntity> list = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      list.add(createSportsSkill(100L + i, member, createSports(10L + i)));
+    }
+    //given
+    when(sportsSkillRepository.findAllByMember(member))
+        .thenReturn(list);
+
+    //when
+    List<SportsSkillDto> sportsSkillDtoList = myPageService.getSportsSkills(member);
+
+    //then
+    for (SportsSkillDto sportsSkill : sportsSkillDtoList) {
+      assertThat(sportsSkill.getSportsGrade()).isEqualTo(SportsGrade.AMATEUR_1);
+    }
+
+  }
+
+  @Test
+  @DisplayName("평가하기")
+  void getRecruitAndParticipants() {
+    /*
+    LocalDateTime을 Mocking 하는 과정에서 문제가 생겨서
+    이부분은 API 테스트로 대체한다.
+
+    해결 하려면 서비스 전체에서 Clock을 Bean으로 등록하여 사용해줘야 한다.
+    이걸 지금 변경하기에는 시간이 너무 많이 들 것 같고,
+    이 문제 때문에 실제 서비스에서 문제 생길 일은 없을 것 같아서 그냥 넘어간다.
+    */
+//    MemberEntity member = createMember(1L);
+//    RecruitEntity recruit1 = createRecruit(10L, member, createSports(1000L));
+//    RecruitEntity recruit2 = createRecruit(20L, member, createSports(1000L));
+//
+//    //thisMemberParticipateList
+//    List<ParticipantEntity> thisMemberParticipateList = new ArrayList<>();
+//    ParticipantEntity thisMemberParticipant1 = createParticipant(100L, member, recruit1);
+//    thisMemberParticipant1.setMeetingDate(LocalDateTime.now().minusDays(1L));
+//
+//    ParticipantEntity thisMemberParticipant2 = createParticipant(101L, member, recruit2);
+//    thisMemberParticipant2.setMeetingDate(LocalDateTime.now().minusDays(1L));
+//
+//    thisMemberParticipateList.add(thisMemberParticipant1);
+//    thisMemberParticipateList.add(thisMemberParticipant2);
+//    when(participantRepository.findAllByMemberAndMeetingDateIsAfter(member, any(LocalDateTime.class)))
+//        .thenReturn(thisMemberParticipateList);
+//
+//    //otherParticipant1
+//    List<ParticipantEntity> otherParticipantRecruit1 = new ArrayList<>();
+//    otherParticipantRecruit1.add(createParticipant(2000L, createMember(2L), recruit1));
+//    otherParticipantRecruit1.add(createParticipant(2001L, createMember(3L), recruit1));
+//    otherParticipantRecruit1.add(createParticipant(2002L, createMember(4L), recruit1));
+//
+//    when(participantRepository.findAllByRecruitAndStatus(recruit1, ParticipantStatus.ACCEPTED))
+//        .thenReturn(otherParticipantRecruit1);
+//
+//    //otherParticipant2
+//    List<ParticipantEntity> otherParticipantRecruit2 = new ArrayList<>();
+//    otherParticipantRecruit1.add(createParticipant(3000L, createMember(2L), recruit2));
+//    otherParticipantRecruit1.add(createParticipant(3001L, createMember(3L), recruit2));
+//    otherParticipantRecruit1.add(createParticipant(3002L, createMember(4L), recruit2));
+//
+//    when(participantRepository.findAllByRecruitAndStatus(recruit2, ParticipantStatus.ACCEPTED))
+//        .thenReturn(otherParticipantRecruit2);
+//
+//    //then
+//    List<RecruitAndParticipants> result =
+//        myPageService.getRecruitAndParticipants(member);
+
+  }
+
+  @Test
+  @DisplayName("내 신청 현황 : Participant List 조회")
+  void getParticipantList() {
+    MemberEntity member = createMember(1L);
+    SportsEntity sports = createSports(100L);
+
+    List<ParticipantEntity> participateList = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      RecruitEntity recruit = createRecruit(10L + i, member, sports);
+      ParticipantEntity participant = createParticipant(50L + i, member, recruit);
+      participateList.add(participant);
+    }
+
+    when(participantRepository.findTop10ByMemberOrderByRegisteredAtDesc(member))
+        .thenReturn(participateList);
+
+    //when
+    List<MyPageParticipant> participantList = myPageService.getParticipantList(member);
+
+    //then
+    for (MyPageParticipant p : participantList) {
+      assertThat(p.getStatus()).isEqualTo(ParticipantStatus.ACCEPTED);
+      assertThat(p.getSportsName()).isEqualTo(sports.getSportsName());
+    }
+  }
+
+  @Test
+  @DisplayName("내 모집 관리")
+  void getMyRecruitList() {
+    MemberEntity member = createMember(1L);
+    SportsEntity sports = createSports(100L);
+
+    //given
+    List<RecruitEntity> findList = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      findList.add(createRecruit(10L + i, member, sports));
+    }
+
+    when(recruitRepository.findTop10ByMemberOrderByMeetingDateDesc(member))
+        .thenReturn(findList);
+
+    //when
+    List<MyPageRecruit> result = myPageService.getMyRecruitList(member);
+
+    //then
+    for (MyPageRecruit myPageRecruit : result) {
+      assertThat(myPageRecruit.getRecruitId()).isNotNull();
+      assertThat(myPageRecruit.getSportsName()).isEqualTo(sports.getSportsName());
+      assertThat(myPageRecruit.getTitle()).isNotNull();
+      assertThat(myPageRecruit.getGender()).isEqualTo(Gender.MALE);
+      assertThat(myPageRecruit.getStatus()).isEqualTo(RecruitStatus.RECRUITING);
+    }
+  }
+
+}

--- a/src/test/java/com/anonymous/usports/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/mypage/service/MyPageServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.when;
 import com.anonymous.usports.domain.member.entity.InterestedSportsEntity;
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.member.repository.InterestedSportsRepository;
-import com.anonymous.usports.domain.member.repository.MemberRepository;
 import com.anonymous.usports.domain.mypage.dto.MyPageMember;
 import com.anonymous.usports.domain.mypage.dto.MyPageParticipant;
 import com.anonymous.usports.domain.mypage.dto.MyPageRecruit;
@@ -234,8 +233,9 @@ class MyPageServiceTest {
 
   }
 
-  @Test
-  @DisplayName("평가하기")
+  /**
+   * 평가하기
+   */
   void getRecruitAndParticipants() {
     /*
     LocalDateTime을 Mocking 하는 과정에서 문제가 생겨서
@@ -243,47 +243,8 @@ class MyPageServiceTest {
 
     해결 하려면 서비스 전체에서 Clock을 Bean으로 등록하여 사용해줘야 한다.
     이걸 지금 변경하기에는 시간이 너무 많이 들 것 같고,
-    이 문제 때문에 실제 서비스에서 문제 생길 일은 없을 것 같아서 그냥 넘어간다.
+    이 문제 때문에 실제 서비스에서 문제 생길 일은 없을 것 같아서 이 메서드는 단위 테스트를 하지 않는다.
     */
-//    MemberEntity member = createMember(1L);
-//    RecruitEntity recruit1 = createRecruit(10L, member, createSports(1000L));
-//    RecruitEntity recruit2 = createRecruit(20L, member, createSports(1000L));
-//
-//    //thisMemberParticipateList
-//    List<ParticipantEntity> thisMemberParticipateList = new ArrayList<>();
-//    ParticipantEntity thisMemberParticipant1 = createParticipant(100L, member, recruit1);
-//    thisMemberParticipant1.setMeetingDate(LocalDateTime.now().minusDays(1L));
-//
-//    ParticipantEntity thisMemberParticipant2 = createParticipant(101L, member, recruit2);
-//    thisMemberParticipant2.setMeetingDate(LocalDateTime.now().minusDays(1L));
-//
-//    thisMemberParticipateList.add(thisMemberParticipant1);
-//    thisMemberParticipateList.add(thisMemberParticipant2);
-//    when(participantRepository.findAllByMemberAndMeetingDateIsAfter(member, any(LocalDateTime.class)))
-//        .thenReturn(thisMemberParticipateList);
-//
-//    //otherParticipant1
-//    List<ParticipantEntity> otherParticipantRecruit1 = new ArrayList<>();
-//    otherParticipantRecruit1.add(createParticipant(2000L, createMember(2L), recruit1));
-//    otherParticipantRecruit1.add(createParticipant(2001L, createMember(3L), recruit1));
-//    otherParticipantRecruit1.add(createParticipant(2002L, createMember(4L), recruit1));
-//
-//    when(participantRepository.findAllByRecruitAndStatus(recruit1, ParticipantStatus.ACCEPTED))
-//        .thenReturn(otherParticipantRecruit1);
-//
-//    //otherParticipant2
-//    List<ParticipantEntity> otherParticipantRecruit2 = new ArrayList<>();
-//    otherParticipantRecruit1.add(createParticipant(3000L, createMember(2L), recruit2));
-//    otherParticipantRecruit1.add(createParticipant(3001L, createMember(3L), recruit2));
-//    otherParticipantRecruit1.add(createParticipant(3002L, createMember(4L), recruit2));
-//
-//    when(participantRepository.findAllByRecruitAndStatus(recruit2, ParticipantStatus.ACCEPTED))
-//        .thenReturn(otherParticipantRecruit2);
-//
-//    //then
-//    List<RecruitAndParticipants> result =
-//        myPageService.getRecruitAndParticipants(member);
-
   }
 
   @Test


### PR DESCRIPTION
### 변경사항
첨부한 이미지 페이지에 GET으로 요청할때 필요한 모든 데이터를 정리하여 반환하는 API 하나를 만들었다.
![image](https://github.com/AnonymousZB14/USports_BE/assets/123939272/7a7bfdfb-5536-4c53-8190-b059e8cd0e32)  

`/mypage`에 접근 시 위의 페이지로 이동하는데, 아래 탭 4개 (평가하기 / 내 신청 현황 / 내 신청 현황 / 내 정보 수정)을 이동할 때 새로운 페이지로 이동하는것이 아닌, 하나의 페이지에서 탭만 변경되도록 한다.

MyPageMainDto라는 클래스에 모든 필요한 데이터가 Profile과 여러개의 List들로 들어간다.
- (기본 회원 정보, 팝업으로 띄워줄 sportSkill List, 평가하기 List, 내 신청 현황 List, 내 모집 관리 List)

**[회원 정보]**
- 기본적인 회원 정보와 InterestSportsEntity의 sportsName만 포함된 List<String>이 포함되어있다.
- InterestSports는 최대 3개까지 랜덤하게 보여주고, 이외의 것들은 +n개 로 표현한다.
- ex) interestSports가 5개인 경우 List<String>의 크기 = 3, plusAlpha = 2

**[운동 능력 정보]**
- 이미지에서 @@@@ 부분을 클릭하면 팝업으로 모든 SportsSkill을 보여준다.
- 따라서 List<SportsSkillDto>를 반환한다.

**[평가하기]**
- 내가 참여했던 Recruit에서 평가를 할 수 있는 Recruit list와 각 Recruit에 대한 참여자 회원 정보 일부를 반환한다.
- RecruitAndParticipant에는 하나의 Recruit와 여러개의 참여자(Participant)의 MemberDto list가 포함된다.

**[내 신청 현황]**
- 내가 신청한 참여 신청 리스트와 현재 상태를 보여준다.
- 최근 10개의 데이터만 포함된다.

**[내 모집 관리]**
- 내가 생성한 모집(Recruit) 리스트가 반환된다.
- 최근 10개의 데이터만 포함된다.

**[내 정보 수정]**
- 기존에는 이 부분에 멤버 데이터를 넣어서 수정할 수 있는 페이지인줄 알고 MemberDto 하나를 반환했다.
- 해당 페이지에는 정보수정과 비밀번호 수정 페이지로 넘어갈 수 있는 버튼이 들어갈 예정이라 이 부분은 마지막에 삭제했다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 
