### PR TITLE
Feature/comment

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/controller/CommentController.java
@@ -1,0 +1,59 @@
+package com.anonymous.usports.domain.comment.controller;
+
+import com.anonymous.usports.domain.comment.dto.CommentDelete;
+import com.anonymous.usports.domain.comment.dto.CommentDto;
+import com.anonymous.usports.domain.comment.dto.CommentRegister;
+import com.anonymous.usports.domain.comment.dto.CommentRegister.Response;
+import com.anonymous.usports.domain.comment.dto.CommentUpdate;
+import com.anonymous.usports.domain.comment.service.CommentService;
+import com.anonymous.usports.domain.member.dto.MemberDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+  private final CommentService commentService;
+
+  @PostMapping("/record/{recordId}/comment")
+  public ResponseEntity<CommentRegister.Response> registerComment(
+      @PathVariable Long recordId,
+      @RequestParam(value = "parent", required = false) Long parentId,
+      @RequestBody CommentRegister.Request request,
+      @AuthenticationPrincipal MemberDto loginMember
+  ) {
+    CommentDto commentDto = commentService.registerComment(recordId, parentId, request, loginMember.getMemberId());
+    return ResponseEntity.ok(new Response(commentDto));
+  }
+
+  @PutMapping("/record/{recordId}/comment/{commentId}")
+  public ResponseEntity<CommentUpdate.Response> updateComment(
+      @PathVariable Long recordId,
+      @PathVariable Long commentId,
+      @RequestBody CommentUpdate.Request request,
+      @AuthenticationPrincipal MemberDto loginMember
+  ) {
+    CommentDto commentDto = commentService.updateComment(recordId,commentId,request, loginMember.getMemberId());
+    return ResponseEntity.ok(new CommentUpdate.Response(commentDto));
+  }
+
+  @DeleteMapping("/record/{recordId}/comment/{commentId}")
+  public ResponseEntity<CommentDelete.Response> deleteComment(
+      @PathVariable Long recordId,
+      @PathVariable Long commentId,
+      @AuthenticationPrincipal MemberDto loginMember
+  ) {
+    CommentDto commentDto = commentService.deleteComment(recordId, commentId, loginMember.getMemberId());
+    return ResponseEntity.ok(new CommentDelete.Response(commentDto));
+  }
+
+}

--- a/src/main/java/com/anonymous/usports/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/controller/CommentController.java
@@ -7,6 +7,7 @@ import com.anonymous.usports.domain.comment.dto.CommentRegister.Response;
 import com.anonymous.usports.domain.comment.dto.CommentUpdate;
 import com.anonymous.usports.domain.comment.service.CommentService;
 import com.anonymous.usports.domain.member.dto.MemberDto;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,6 +25,7 @@ public class CommentController {
 
   private final CommentService commentService;
 
+  @ApiOperation("댓글 작성")
   @PostMapping("/record/{recordId}/comment")
   public ResponseEntity<CommentRegister.Response> registerComment(
       @PathVariable Long recordId,
@@ -35,6 +37,7 @@ public class CommentController {
     return ResponseEntity.ok(new Response(commentDto));
   }
 
+  @ApiOperation("댓글 수정")
   @PutMapping("/record/{recordId}/comment/{commentId}")
   public ResponseEntity<CommentUpdate.Response> updateComment(
       @PathVariable Long recordId,
@@ -46,6 +49,7 @@ public class CommentController {
     return ResponseEntity.ok(new CommentUpdate.Response(commentDto));
   }
 
+  @ApiOperation("댓글 삭제")
   @DeleteMapping("/record/{recordId}/comment/{commentId}")
   public ResponseEntity<CommentDelete.Response> deleteComment(
       @PathVariable Long recordId,

--- a/src/main/java/com/anonymous/usports/domain/comment/dto/CommentDelete.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/dto/CommentDelete.java
@@ -1,0 +1,26 @@
+package com.anonymous.usports.domain.comment.dto;
+
+import com.anonymous.usports.global.constant.ResponseConstant;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class CommentDelete {
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Response {
+
+    private Long commentId;
+    private String message;
+
+    public Response (CommentDto commentDto){
+      this.commentId = commentDto.getCommentId();
+      this.message = ResponseConstant.DELETE_COMMENT;
+    }
+  }
+
+}

--- a/src/main/java/com/anonymous/usports/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/dto/CommentDto.java
@@ -1,0 +1,44 @@
+package com.anonymous.usports.domain.comment.dto;
+
+import com.anonymous.usports.domain.comment.entity.CommentEntity;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class CommentDto {
+
+  private Long commentId;
+
+  private Long memberId;
+
+  private Long recordId;
+
+  private String content;
+
+  private LocalDateTime registerAt;
+
+  private LocalDateTime updatedAt;
+
+  private Long parentId;
+
+  public static CommentDto fromEntity(CommentEntity commentEntity) {
+    return CommentDto.builder()
+        .commentId(commentEntity.getCommentId())
+        .memberId(commentEntity.getMember().getMemberId())
+        .recordId(commentEntity.getRecord().getRecordId())
+        .content(commentEntity.getContent())
+        .registerAt(commentEntity.getRegisteredAt())
+        .updatedAt(commentEntity.getUpdatedAt())
+        .parentId(commentEntity.getParentId())
+        .build();
+  }
+
+}

--- a/src/main/java/com/anonymous/usports/domain/comment/dto/CommentRegister.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/dto/CommentRegister.java
@@ -1,0 +1,48 @@
+package com.anonymous.usports.domain.comment.dto;
+
+import com.anonymous.usports.domain.comment.entity.CommentEntity;
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.record.entity.RecordEntity;
+import com.anonymous.usports.global.constant.ResponseConstant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class CommentRegister {
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Request {
+    private String content;
+
+    public static CommentEntity toEntity(CommentRegister.Request request, MemberEntity member, RecordEntity record, Long parent) {
+      return CommentEntity.builder()
+          .member(member)
+          .record(record)
+          .content(request.getContent())
+          .parentId(parent)
+          .build();
+    }
+  }
+
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Getter
+  @Setter
+  @Builder
+  public static class Response {
+    private Long commentId;
+    private String message;
+
+    public Response(CommentDto commentDto){
+      this.commentId = commentDto.getCommentId();
+      this.message = ResponseConstant.CREATE_COMMENT;
+    }
+  }
+
+}

--- a/src/main/java/com/anonymous/usports/domain/comment/dto/CommentUpdate.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/dto/CommentUpdate.java
@@ -1,0 +1,49 @@
+package com.anonymous.usports.domain.comment.dto;
+
+import com.anonymous.usports.domain.comment.entity.CommentEntity;
+import com.anonymous.usports.global.constant.ResponseConstant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class CommentUpdate {
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Request{
+    private String content;
+
+    public static CommentEntity toEntity(CommentUpdate.Request request, CommentEntity comment) {
+      return CommentEntity.builder()
+          .commentId(comment.getCommentId())
+          .member(comment.getMember())
+          .record(comment.getRecord())
+          .content(request.getContent())
+          .registeredAt(comment.getRegisteredAt())
+          .updatedAt(comment.getUpdatedAt())
+          .parentId(comment.getParentId())
+          .build();
+    }
+  }
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Response {
+    private Long commentId;
+    private String message;
+
+    public Response(CommentDto commentDto) {
+      this.commentId = commentDto.getCommentId();
+      this.message = ResponseConstant.UPDATE_COMMENT;
+    }
+  }
+
+}

--- a/src/main/java/com/anonymous/usports/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/entity/CommentEntity.java
@@ -1,0 +1,75 @@
+package com.anonymous.usports.domain.comment.entity;
+
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.record.entity.RecordEntity;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity(name = "comment")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class CommentEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "comment_id", nullable = false)
+  private Long commentId;
+
+  @ManyToOne
+  @JoinColumn(name = "member_id", nullable = false)
+  private MemberEntity member;
+
+  @ManyToOne
+  @JoinColumn(name = "record_id", nullable = false)
+  private RecordEntity record;
+
+  @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+  private String content;
+
+  @Column(name = "registered_at", nullable = false)
+  @CreatedDate
+  private LocalDateTime registeredAt;
+
+  @Column(name = "updated_at", nullable = false)
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+
+  @Column(name = "parent_id")
+  private Long parentId;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CommentEntity comment = (CommentEntity) o;
+    return Objects.equals(commentId, comment.commentId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(commentId);
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,20 @@
+package com.anonymous.usports.domain.comment.repository;
+
+import com.anonymous.usports.domain.comment.entity.CommentEntity;
+import com.anonymous.usports.domain.record.entity.RecordEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
+  List<CommentEntity> findAllByParentId(Long parentId);
+
+  List<CommentEntity> findAllByRecord(RecordEntity recordEntity);
+
+  boolean existsByRecord(RecordEntity recordEntity);
+
+
+
+
+}

--- a/src/main/java/com/anonymous/usports/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/repository/CommentRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
   List<CommentEntity> findAllByParentId(Long parentId);
 
-  List<CommentEntity> findAllByRecord(RecordEntity recordEntity);
+  boolean existsByCommentId(Long commentId);
 
   boolean existsByRecord(RecordEntity recordEntity);
 

--- a/src/main/java/com/anonymous/usports/domain/comment/service/CommentService.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/service/CommentService.java
@@ -1,0 +1,14 @@
+package com.anonymous.usports.domain.comment.service;
+
+import com.anonymous.usports.domain.comment.dto.CommentDto;
+import com.anonymous.usports.domain.comment.dto.CommentRegister.Request;
+import com.anonymous.usports.domain.comment.dto.CommentUpdate;
+
+public interface CommentService {
+
+  CommentDto registerComment(Long recordId, Long parentId, Request request, Long loginMemberId);
+
+  CommentDto updateComment(Long recordId, Long commentId, CommentUpdate.Request request, Long loginMemberId);
+
+  CommentDto deleteComment(Long recordId, Long commentId, Long loginMemberId);
+}

--- a/src/main/java/com/anonymous/usports/domain/comment/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/service/impl/CommentServiceImpl.java
@@ -1,0 +1,86 @@
+package com.anonymous.usports.domain.comment.service.impl;
+
+import com.anonymous.usports.domain.comment.dto.CommentDto;
+import com.anonymous.usports.domain.comment.dto.CommentRegister.Request;
+import com.anonymous.usports.domain.comment.dto.CommentUpdate;
+import com.anonymous.usports.domain.comment.entity.CommentEntity;
+import com.anonymous.usports.domain.comment.repository.CommentRepository;
+import com.anonymous.usports.domain.comment.service.CommentService;
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.domain.record.entity.RecordEntity;
+import com.anonymous.usports.domain.record.repository.RecordRepository;
+import com.anonymous.usports.global.exception.CommentException;
+import com.anonymous.usports.global.exception.ErrorCode;
+import com.anonymous.usports.global.exception.MemberException;
+import com.anonymous.usports.global.exception.RecordException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+  private final MemberRepository memberRepository;
+  private final RecordRepository recordRepository;
+  private final CommentRepository commentRepository;
+
+  @Override
+  @Transactional
+  public CommentDto registerComment(Long recordId, Long parentId, Request request, Long loginMemberId) {
+    RecordEntity record = recordRepository.findById(recordId)
+        .orElseThrow(()->new RecordException(ErrorCode.RECORD_NOT_FOUND));
+    MemberEntity loginMember = memberRepository.findById(loginMemberId)
+        .orElseThrow(()->new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+    CommentEntity comment = commentRepository.save(Request.toEntity(request,loginMember,record,parentId));
+    record.setCountComment(record.getCountComment()+1);
+    recordRepository.save(record);
+    return CommentDto.fromEntity(comment);
+  }
+
+  @Override
+  @Transactional
+  public CommentDto updateComment(Long recordId, Long commentId, CommentUpdate.Request request,
+      Long loginMemberId) {
+    recordRepository.findById(recordId)
+        .orElseThrow(()->new RecordException(ErrorCode.RECORD_NOT_FOUND));
+    CommentEntity comment = commentRepository.findById(commentId)
+        .orElseThrow(()->new CommentException(ErrorCode.COMMENT_NOT_FOUND));
+    memberRepository.findById(loginMemberId)
+        .orElseThrow(()->new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+    if(!comment.getMember().getMemberId().equals(loginMemberId)){
+      throw new MemberException(ErrorCode.NO_AUTHORITY_ERROR);
+    }
+    List<CommentEntity> replies = commentRepository.findAllByParentId(commentId);
+    if (!replies.isEmpty()) {
+      throw new CommentException(ErrorCode.CANNOT_EDIT_PARENT_COMMENT);
+    }
+    CommentEntity updatedComment = commentRepository.save(CommentUpdate.Request.toEntity(request,comment));
+    return CommentDto.fromEntity(updatedComment);
+  }
+
+  @Override
+  @Transactional
+  public CommentDto deleteComment(Long recordId, Long commentId, Long loginMemberId) {
+    RecordEntity record = recordRepository.findById(recordId)
+        .orElseThrow(()->new RecordException(ErrorCode.RECORD_NOT_FOUND));
+    CommentEntity comment = commentRepository.findById(commentId)
+        .orElseThrow(()->new CommentException(ErrorCode.COMMENT_NOT_FOUND));
+    memberRepository.findById(loginMemberId)
+        .orElseThrow(()->new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+    if(!comment.getMember().getMemberId().equals(loginMemberId)){
+      throw new MemberException(ErrorCode.NO_AUTHORITY_ERROR);
+    }
+    List<CommentEntity> replies = commentRepository.findAllByParentId(commentId);
+    if (!replies.isEmpty()) {
+      commentRepository.deleteAll(replies);
+    }
+    commentRepository.delete(comment);
+    record.setCountComment(record.getCountComment()-1);
+    recordRepository.save(record);
+    return CommentDto.fromEntity(comment);
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/comment/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/service/impl/CommentServiceImpl.java
@@ -27,6 +27,15 @@ public class CommentServiceImpl implements CommentService {
   private final RecordRepository recordRepository;
   private final CommentRepository commentRepository;
 
+  /**
+   * 댓글 작성 메서드
+   *
+   * @param recordId 기록 Id
+   * @param parentId parentId null이면 일반 댓글, 값이 있을 경우 해당 댓글의 대댓글
+   * @param request 댓글 content
+   * @param loginMemberId 로그인 한 회원 Id
+   * @return CommentDto로 반환
+   */
   @Override
   @Transactional
   public CommentDto registerComment(Long recordId, Long parentId, Request request, Long loginMemberId) {
@@ -44,6 +53,15 @@ public class CommentServiceImpl implements CommentService {
     return CommentDto.fromEntity(comment);
   }
 
+  /**
+   * 댓글 수정 메서드
+   *
+   * @param recordId
+   * @param commentId
+   * @param request
+   * @param loginMemberId
+   * @return
+   */
   @Override
   @Transactional
   public CommentDto updateComment(Long recordId, Long commentId, CommentUpdate.Request request,
@@ -72,6 +90,7 @@ public class CommentServiceImpl implements CommentService {
     List<CommentEntity> replies = commentRepository.findAllByParentId(commentId);
     if (!replies.isEmpty()) {
       commentRepository.deleteAll(replies);
+      record.setCountComment(record.getCountComment()-replies.size());
     }
     commentRepository.delete(comment);
     record.setCountComment(record.getCountComment()-1);

--- a/src/main/java/com/anonymous/usports/domain/comment/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/service/impl/CommentServiceImpl.java
@@ -56,11 +56,11 @@ public class CommentServiceImpl implements CommentService {
   /**
    * 댓글 수정 메서드
    *
-   * @param recordId
-   * @param commentId
-   * @param request
-   * @param loginMemberId
-   * @return
+   * @param recordId 기록 Id
+   * @param commentId 수정할 commentId
+   * @param request 댓글 content
+   * @param loginMemberId 로그인 한 회원 Id
+   * @return CommentDto로 반환
    */
   @Override
   @Transactional
@@ -79,6 +79,14 @@ public class CommentServiceImpl implements CommentService {
     return CommentDto.fromEntity(updatedComment);
   }
 
+  /**
+   * 댓글 삭제 메서드
+   *
+   * @param recordId 기록 Id
+   * @param commentId 수정할 commentId
+   * @param loginMemberId 로그인 한 회원 Id
+   * @return CommentDto로 반환
+   */
   @Override
   @Transactional
   public CommentDto deleteComment(Long recordId, Long commentId, Long loginMemberId) {
@@ -97,6 +105,13 @@ public class CommentServiceImpl implements CommentService {
     recordRepository.save(record);
     return CommentDto.fromEntity(comment);
   }
+
+  /**
+   * 회원 정보 조회 및 댓글 작성 회원과 일치 여부 확인
+   *
+   * @param comment 해당 댓글
+   * @param loginMemberId 로그인 한 회원 Id
+   */
   private void validateMemberAndAuthority(CommentEntity comment, Long loginMemberId) {
     memberRepository.findById(loginMemberId)
         .orElseThrow(()->new MemberException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/anonymous/usports/global/constant/ResponseConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/ResponseConstant.java
@@ -35,4 +35,9 @@ public class ResponseConstant {
   public static final String DELETE_FOLLOW = "팔로우를 삭제했습니다.";
   public static final String ACCEPT_FOLLOW = "팔로우를 수락했습니다.";
   public static final String REFUSE_FOLLOW = "팔로우를 거절했습니다.";
+
+  // 댓글 관련
+  public static final String CREATE_COMMENT = "댓글을 등록했습니다.";
+  public static final String UPDATE_COMMENT = "댓글을 수정했습니다.";
+  public static final String DELETE_COMMENT = "댓글을 삭제했습니다.";
 }

--- a/src/main/java/com/anonymous/usports/global/exception/CommentException.java
+++ b/src/main/java/com/anonymous/usports/global/exception/CommentException.java
@@ -1,0 +1,22 @@
+package com.anonymous.usports.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class CommentException extends RuntimeException{
+  private ErrorCode errorCode;
+  private String errorMessage;
+
+  public CommentException(ErrorCode errorCode) {
+    this.errorCode = errorCode;
+    this.errorMessage = errorCode.getDescription();
+  }
+}

--- a/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
+++ b/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
@@ -41,8 +41,10 @@ public enum ErrorCode {
   //Evaluation 관련
   EVALUATION_ALREADY_EXISTS(HttpStatus.NOT_FOUND, "이미 평가가 완료된 건 입니다."),
 
-
-
+  //Comment 관련
+  COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST,"댓글을 찾을 수 없습니다."),
+  CANNOT_EDIT_PARENT_COMMENT(HttpStatus.BAD_REQUEST,"원댓글은 수정할 수 없습니다."),
+  CANNOT_DELETE_PARENT_COMMENT(HttpStatus.BAD_REQUEST,"원댓글은 삭제할 수 없습니다."),
 
   //Record 관련
   IMAGE_SAVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"이미지 저장 오류가 발생했습니다."),
@@ -56,6 +58,7 @@ public enum ErrorCode {
   RECORD_UPDATE_ERROR(HttpStatus.BAD_REQUEST,"기록 수정 중 에러가 발생했습니다."),
   RECORD_DELETE_ERROR(HttpStatus.BAD_REQUEST,"기록 삭제 중 에러가 발생했습니다."),
   INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST,"업로드 할 수 없는 확장자입니다."),
+  CANNOT_DELETE_RECORD_FOR_COMMENT(HttpStatus.BAD_REQUEST,"댓글이 있는 게시글은 삭제할 수 없습니다."),
 
   //Follow 관련
   FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND,"팔로우를 찾을 수 없습니다."),

--- a/src/main/java/com/anonymous/usports/global/exception/MyExceptionHandler.java
+++ b/src/main/java/com/anonymous/usports/global/exception/MyExceptionHandler.java
@@ -52,6 +52,11 @@ public class MyExceptionHandler {
     return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatusCode());
   }
 
+  @ExceptionHandler(CommentException.class)
+  public ResponseEntity<ErrorResponse> handleRecordException(CommentException e) {
+    ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
+    return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatusCode());
+  }
 
 
 }

--- a/src/test/java/com/anonymous/usports/domain/comment/service/impl/CommentServiceImplTest.java
+++ b/src/test/java/com/anonymous/usports/domain/comment/service/impl/CommentServiceImplTest.java
@@ -1,0 +1,520 @@
+package com.anonymous.usports.domain.comment.service.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.anonymous.usports.domain.comment.dto.CommentDto;
+import com.anonymous.usports.domain.comment.dto.CommentRegister;
+import com.anonymous.usports.domain.comment.dto.CommentRegister.Request;
+import com.anonymous.usports.domain.comment.dto.CommentUpdate;
+import com.anonymous.usports.domain.comment.entity.CommentEntity;
+import com.anonymous.usports.domain.comment.repository.CommentRepository;
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.domain.record.entity.RecordEntity;
+import com.anonymous.usports.domain.record.repository.RecordRepository;
+import com.anonymous.usports.domain.sports.entity.SportsEntity;
+import com.anonymous.usports.domain.sports.repository.SportsRepository;
+import com.anonymous.usports.global.exception.CommentException;
+import com.anonymous.usports.global.exception.ErrorCode;
+import com.anonymous.usports.global.exception.MemberException;
+import com.anonymous.usports.global.exception.RecordException;
+import com.anonymous.usports.global.type.Gender;
+import com.anonymous.usports.global.type.Role;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceImplTest {
+
+  @Mock
+  private MemberRepository memberRepository;
+  @Mock
+  private RecordRepository recordRepository;
+  @Mock
+  private CommentRepository commentRepository;
+  @InjectMocks
+  private CommentServiceImpl commentService;
+
+  private MemberEntity createMember(Long id) {
+    return MemberEntity.builder()
+        .memberId(id)
+        .accountName("testAccountName" + id)
+        .name("testName" + id)
+        .email("test@test" + id + ".com")
+        .password("password" + id)
+        .phoneNumber("010-1111-111" + id)
+        .birthDate(LocalDate.now())
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .profileOpen(true)
+        .build();
+  }
+  private SportsEntity createSports(Long id,String sportsName) {
+    return SportsEntity.builder()
+        .sportsId(id)
+        .sportsName(sportsName)
+        .build();
+  }
+  private RecordEntity createRecord(Long id, MemberEntity member, SportsEntity sports) {
+    List<String> images = new ArrayList<>();
+    for(int i=0; i<3;i++){
+      images.add("http://이미지주소"+id+".com");
+    }
+    return RecordEntity.builder()
+        .recordId(id)
+        .member(member)
+        .sports(sports)
+        .recordContent("테스트 기록 내용"+id)
+        .registeredAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .countComment(0L)
+        .imageAddress(images)
+        .build();
+  }
+  private CommentEntity createComment(Long id,MemberEntity member,RecordEntity record,Long parentId) {
+    return CommentEntity.builder()
+        .commentId(id)
+        .member(member)
+        .record(record)
+        .content("댓글 테스트입니다.")
+        .registeredAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .parentId(parentId)
+        .build();
+  }
+
+
+  @Nested
+  @DisplayName("댓글 등록")
+  class registerComment {
+
+    @Test
+    @DisplayName("성공-댓글 등록")
+    void success_Comment() {
+      MemberEntity member = createMember(1L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+      CommentEntity comment = createComment(1000L,member,record,null);
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+
+
+      CommentRegister.Request request = new Request("댓글 테스트입니다.");
+
+      when(commentRepository.save(Request.toEntity(request,member,record,null)))
+          .thenReturn(comment);
+
+
+
+      CommentDto result =
+          commentService.registerComment(record.getRecordId(),null,request,member.getMemberId());
+
+      verify(commentRepository,times(1)).save(new CommentEntity());
+      verify(recordRepository,times(1)).save(record);
+
+      assertEquals(result.getMemberId(),comment.getMember().getMemberId());
+      assertEquals(result.getRecordId(),comment.getRecord().getRecordId());
+      assertEquals(result.getParentId(),comment.getParentId());
+      assertThat(result.getContent()).isEqualTo(comment.getContent());
+
+    }
+    @Test
+    @DisplayName("성공-대댓글 등록")
+    void success_registerReply() {
+      MemberEntity member = createMember(1L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+      CommentEntity comment = createComment(1000L,member,record,null);
+      CommentEntity reply = createComment(1200L,member,record,1000L);
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+
+
+      CommentRegister.Request request = new Request("댓글 테스트입니다.");
+
+      when(commentRepository.save(Request.toEntity(request,member,record,comment.getCommentId())))
+          .thenReturn(reply);
+
+      CommentDto result =
+          commentService.registerComment(record.getRecordId(), comment.getCommentId(), request,member.getMemberId());
+
+      verify(commentRepository,times(1)).save(new CommentEntity());
+      verify(recordRepository,times(1)).save(record);
+
+      assertEquals(result.getMemberId(),reply.getMember().getMemberId());
+      assertEquals(result.getRecordId(),reply.getRecord().getRecordId());
+      assertEquals(result.getParentId(),reply.getParentId());
+      assertThat(result.getContent()).isEqualTo(reply.getContent());
+
+    }
+    @Test
+    @DisplayName("실패-MEMBER_NOT_FOUND")
+    void fail_MemberNotFound() {
+      MemberEntity member = createMember(1L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.empty());
+
+      CommentRegister.Request request = new Request("댓글 테스트입니다.");
+
+      MemberException exception =
+          catchThrowableOfType(()->
+              commentService.registerComment(record.getRecordId(),null,request,member.getMemberId()),
+          MemberException.class);
+      assertEquals(exception.getErrorCode(),ErrorCode.MEMBER_NOT_FOUND);
+    }
+    @Test
+    @DisplayName("실패-RECORD_NOT_FOUND")
+    void fail_RecordNotFound() {
+      MemberEntity member = createMember(1L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.empty());
+
+      CommentRegister.Request request = new Request("댓글 테스트입니다.");
+
+      RecordException exception =
+          catchThrowableOfType(()->
+                  commentService.registerComment(record.getRecordId(),null,request,member.getMemberId()),
+              RecordException.class);
+      assertEquals(exception.getErrorCode(),ErrorCode.RECORD_NOT_FOUND);
+    }
+  }
+
+  @Nested
+  @DisplayName("댓글 수정")
+  class updateComment {
+    private CommentEntity createUpdateComment(CommentEntity comment, CommentUpdate.Request request){
+      return CommentEntity.builder()
+          .commentId(comment.getCommentId())
+          .member(comment.getMember())
+          .record(comment.getRecord())
+          .registeredAt(comment.getRegisteredAt())
+          .updatedAt(LocalDateTime.now())
+          .parentId(comment.getParentId())
+          .content(request.getContent())
+          .build();
+    }
+
+    @Test
+    @DisplayName("성공-대댓글 없을 때 댓글 수정")
+    void success_updateComment(){
+      MemberEntity member = createMember(1L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+      CommentEntity comment = createComment(1000L,member,record,null);
+      CommentUpdate.Request request = new CommentUpdate.Request("댓글 수정 테스트입니다.");
+      CommentEntity updateComment = createUpdateComment(comment,request);
+
+      when(commentRepository.findById(1000L))
+          .thenReturn(Optional.of(comment));
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+      when(commentRepository.findAllByParentId(1000L))
+          .thenReturn(Collections.emptyList());
+      when(commentRepository.save(comment))
+          .thenReturn(updateComment);
+
+      CommentDto result =
+          commentService.updateComment
+              (record.getRecordId(), comment.getCommentId(), request,member.getMemberId());
+
+      verify(commentRepository,times(1)).save(updateComment);
+
+      assertEquals(result.getMemberId(),comment.getMember().getMemberId());
+      assertNotEquals(result.getContent(),comment.getContent());
+//      assertNotEquals(result.getUpdatedAt(),comment.getRegisteredAt());TODO 테스트 상에서 registerdAt과 updatedAt 차이가 없음. 디버깅 시는 차이 발생
+      assertEquals(result.getRecordId(),comment.getRecord().getRecordId());
+      assertEquals(result.getCommentId(),comment.getCommentId());
+    }
+    @Test
+    @DisplayName("실패-대댓글 있을 때 댓글 수정")
+    void fail_updateCommentExistComment(){
+      MemberEntity member = createMember(1L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+      CommentEntity comment = createComment(1000L,member,record,null);
+      CommentUpdate.Request request = new CommentUpdate.Request("댓글 수정 테스트입니다.");
+      List<CommentEntity> customRepliesList = Arrays.asList(
+          createComment(2000L, member, record, comment.getCommentId()),
+          createComment(3000L, member, record, comment.getCommentId())
+      );
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+      when(commentRepository.findById(1000L))
+          .thenReturn(Optional.of(comment));
+      when(commentRepository.findAllByParentId(1000L))
+          .thenReturn(customRepliesList);
+
+      CommentException exception =
+          catchThrowableOfType(()->
+                  commentService.updateComment(record.getRecordId(), comment.getCommentId(), request,member.getMemberId()),
+              CommentException.class);
+      assertEquals(exception.getErrorCode(),ErrorCode.CANNOT_EDIT_PARENT_COMMENT);
+    }
+    @Test
+    @DisplayName("실패-RECORD_NOT_FOUND")
+    void fail_RecordNotFound(){
+      MemberEntity member = createMember(1L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+      CommentEntity comment = createComment(1000L,member,record,null);
+      CommentUpdate.Request request = new CommentUpdate.Request("댓글 수정 테스트입니다.");
+
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.empty());
+
+
+      RecordException exception =
+          catchThrowableOfType(()->
+                  commentService.updateComment(record.getRecordId(), comment.getCommentId(), request,member.getMemberId()),
+              RecordException.class);
+      assertEquals(exception.getErrorCode(),ErrorCode.RECORD_NOT_FOUND);
+    }
+    @Test
+    @DisplayName("실패-COMMENT_NOT_FOUND")
+    void fail_CommentNotFound(){
+      MemberEntity member = createMember(1L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+      CommentEntity comment = createComment(1000L,member,record,null);
+      CommentUpdate.Request request = new CommentUpdate.Request("댓글 수정 테스트입니다.");
+
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+      when(commentRepository.findById(1000L))
+          .thenReturn(Optional.empty());
+
+      CommentException exception =
+          catchThrowableOfType(()->
+                  commentService.updateComment(record.getRecordId(), comment.getCommentId(), request,member.getMemberId()),
+              CommentException.class);
+      assertEquals(exception.getErrorCode(),ErrorCode.COMMENT_NOT_FOUND);
+    }
+    @Test
+    @DisplayName("실패-MEMBER_NOT_FOUND")
+    void fail_MemberNotFound(){
+      MemberEntity member = createMember(1L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+      CommentEntity comment = createComment(1000L,member,record,null);
+      CommentUpdate.Request request = new CommentUpdate.Request("댓글 수정 테스트입니다.");
+
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.empty());
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+      when(commentRepository.findById(1000L))
+          .thenReturn(Optional.of(comment));
+
+      MemberException exception =
+          catchThrowableOfType(()->
+                  commentService.updateComment(record.getRecordId(), comment.getCommentId(), request,member.getMemberId()),
+              MemberException.class);
+      assertEquals(exception.getErrorCode(),ErrorCode.MEMBER_NOT_FOUND);
+    }
+    @Test
+    @DisplayName("실패-NO_AUTHORITY_ERROR")
+    void fail_NoAuthorityError(){
+      MemberEntity member = createMember(1L);
+      MemberEntity otherMember = createMember(2L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+      CommentEntity comment = createComment(1000L,otherMember,record,null);
+      CommentUpdate.Request request = new CommentUpdate.Request("댓글 수정 테스트입니다.");
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+      when(commentRepository.findById(1000L))
+          .thenReturn(Optional.of(comment));
+
+
+      MemberException exception =
+          catchThrowableOfType(()->
+                  commentService.updateComment(record.getRecordId(), comment.getCommentId(), request,member.getMemberId()),
+              MemberException.class);
+      assertEquals(exception.getErrorCode(),ErrorCode.NO_AUTHORITY_ERROR);
+    }
+  }
+
+  @Nested
+  @DisplayName("댓글 삭제")
+  class deleteComment {
+    @Test
+    @DisplayName("성공-댓글 삭제")
+    void success_deleteComment(){
+      MemberEntity member = createMember(1L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+      CommentEntity comment = createComment(1000L,member,record,null);
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+      when(commentRepository.findById(1000L))
+          .thenReturn(Optional.of(comment));
+      when(commentRepository.findAllByParentId(1000L))
+          .thenReturn(Collections.emptyList());
+
+      CommentDto result =
+          commentService.deleteComment
+              (record.getRecordId(), comment.getCommentId(),member.getMemberId());
+
+      verify(commentRepository,times(1)).delete(comment);
+
+      assertEquals(result.getCommentId(), comment.getCommentId());
+    }
+    @Test
+    @DisplayName("성공-대댓글이 달렸을 때 댓글 삭제")
+    void success_deleteCommentExistReply(){
+      MemberEntity member = createMember(1L);
+      MemberEntity otherMember = createMember(2L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+      CommentEntity comment = createComment(1000L,member,record,null);
+      List<CommentEntity> customRepliesList = Arrays.asList(
+          createComment(2000L, otherMember, record, comment.getCommentId()),
+          createComment(3000L, member, record, comment.getCommentId())
+      );
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+      when(commentRepository.findById(1000L))
+          .thenReturn(Optional.of(comment));
+      when(commentRepository.findAllByParentId(1000L))
+          .thenReturn(customRepliesList);
+
+
+      CommentDto result =
+          commentService.deleteComment
+              (record.getRecordId(), comment.getCommentId(),member.getMemberId());
+
+      verify(commentRepository,times(1)).delete(comment);
+      verify(commentRepository,times(1)).deleteAll(customRepliesList);
+
+      assertEquals(result.getCommentId(), comment.getCommentId());
+    }
+    @Test
+    @DisplayName("실패-RECORD_NOT_FOUND")
+    void fail_RecordNotFound(){
+      MemberEntity member = createMember(1L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+      CommentEntity comment = createComment(1000L,member,record,null);
+
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.empty());
+
+      RecordException exception =
+          catchThrowableOfType(()->
+                  commentService.deleteComment(record.getRecordId(), comment.getCommentId(),member.getMemberId()),
+              RecordException.class);
+      assertEquals(exception.getErrorCode(),ErrorCode.RECORD_NOT_FOUND);
+    }
+    @Test
+    @DisplayName("실패-COMMENT_NOT_FOUND")
+    void fail_CommentNotFound(){
+      MemberEntity member = createMember(1L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+      CommentEntity comment = createComment(1000L,member,record,null);
+
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+      when(commentRepository.findById(1000L))
+          .thenReturn(Optional.empty());
+
+      CommentException exception =
+          catchThrowableOfType(()->
+                  commentService.deleteComment(record.getRecordId(), comment.getCommentId(),member.getMemberId()),
+              CommentException.class);
+      assertEquals(exception.getErrorCode(),ErrorCode.COMMENT_NOT_FOUND);
+    }
+    @Test
+    @DisplayName("실패-MEMBER_NOT_FOUND")
+    void fail_MemberNotFound(){
+      MemberEntity member = createMember(1L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+      CommentEntity comment = createComment(1000L,member,record,null);
+
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+      when(commentRepository.findById(1000L))
+          .thenReturn(Optional.of(comment));
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.empty());
+
+      MemberException exception =
+          catchThrowableOfType(()->
+                  commentService.deleteComment(record.getRecordId(), comment.getCommentId(),member.getMemberId()),
+              MemberException.class);
+      assertEquals(exception.getErrorCode(),ErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패-NO_AUTHORITY_ERROR")
+    void fail_NO_AUTHORITY_ERROR(){
+      MemberEntity member = createMember(1L);
+      MemberEntity otherMember = createMember(2L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L, member, sports);
+      CommentEntity comment = createComment(1000L,otherMember,record,null);
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+      when(commentRepository.findById(1000L))
+          .thenReturn(Optional.of(comment));
+
+      MemberException exception =
+          catchThrowableOfType(()->
+                  commentService.deleteComment(record.getRecordId(), comment.getCommentId(),member.getMemberId()),
+              MemberException.class);
+      assertEquals(exception.getErrorCode(),ErrorCode.NO_AUTHORITY_ERROR);
+    }
+  }
+}


### PR DESCRIPTION
# 변경사항

## AS-IS

Record에 댓글을 다는 기능입니다. 

### [추가된 기능]

**1. 댓글 등록 기능**

댓글을 등록하는 기능입니다.
기존 댓글에 추가로 댓글(대댓글)을 등록할 수 있습니다.

예외 발생 상황
- 댓글을 달 기록 게시물을 찾지 못할 경우(RECORD_NOT_FOUND)
- 댓글 달 회원 정보를 찾지 못할 경우(MEMBER_NOT_FOUND)
- parentId가 null이 아니나 parentId의 값과 일치하는 commentId가 없을 경우(COMMENT_NOT_FOUND)


**2. 댓글 수정 기능**

기존에 등록했던 댓글을 수정할 수 있는 기능입니다.
대댓글이 존재할 경우 수정 불가합니다.

예외 발생 상황
- 댓글이 달려있는 기록 게시물을 찾지 못할 경우(RECORD_NOT_FOUND)
- 수정할 코멘트를 찾지 못할 경우(COMMENT_NOT_FOUND)
- 댓글 수정할 회원 정보를 찾지 못할 경우(MEMBER_NOT_FOUND)
- 로그인 한 회원과 댓글 작성 회원이 다른 경우(NO_AUTHORITY_ERROR)
- 수정할 댓글에 이미 대댓글이 달린 경우 수정 불가(CANNOT_EDIT_PARENT_COMMENT)

**3. 댓글 삭제 기능**

기존에 등록했던 댓글을 삭제하는 기능입니다.
수정하는 경우와 다르게 대댓글이 달린 댓글을 삭제할 경우 대댓글까지 같이 삭제됩니다.

예외 발생 상황
- 댓글이 달려있는 기록 게시물을 찾지 못할 경우(RECORD_NOT_FOUND)
- 삭제할 코멘트를 찾지 못할 경우(COMMENT_NOT_FOUND)
- 댓글 삭제할 회원 정보를 찾지 못할 경우(MEMBER_NOT_FOUND)
- 로그인 한 회원과 댓글 작성 회원이 다른 경우(NO_AUTHORITY_ERROR)

### [API 테스트 케이스]
Postman을 이용하여
기록 1과 회원 1, 회원 2 생성하여 테스트 진행

**1. 댓글 등록**
- 회원 1로 로그인 한 후 기록 1에 댓글(commentId:1) 등록 후 확인
- 회원 2로 로그인 한 수 기록 1에 댓글(commentId:2) 등록 후 확인
- 회원 1로 회원 2가 남긴 댓글(commentId:2)에 대댓글(commentId:3) 등록 후 확인
-  회원 2로 회원 2가 남긴 댓글(commentId:2)에 대댓글(commentId:4) 등록 후 확인
- 존재하지 않는 기록으로 등록 요청했을 때 RECORD_NOT_FOUND 확인
- 존재하지 않는 commentId를 넣어서 요청했을 때 COMMENT_NOT_FOUND 확인
- parentId가 null 일 때는 DB에 parentId가 null로 들어가고 parentId의 값이 있을 경우 해당 값이 들어감을 확인

**2. 댓글 수정**
- 존재하지 않는 기록으로 수정 요청했을 때 RECORD_NOT_FOUND 확인
- 회원 2가 남긴 댓글(commentId:2) 수정 시도 시 대댓글(commentId:3)이 있기 때문에 CANNOT_EDIT_PARENT_COMMENT 확인
- 회원 2가 회원 2가 남긴 대댓글(commentId:4) 수정 성공 확인
- 회원 1이 자신이 남긴 댓글(commentId:1) 수정 성공 확인
- 회원 2가 남긴 대댓글(commentId:4)를 회원 1이 수정하려 했을 때 NO_AUTHORITY_ERROR 확인
- 회원 1이 남긴 댓글(commentId:1)을 회원 2가 수정하려 했을 때 NO_AUTHORITY_ERROR 확인
- 존재하지 않는 commentId로 요청이 들어올 경우 COMMENT_NOT_FOUND 확인

**3. 댓글 삭제**
- 존재하지 않는 기록으로 삭제 요청했을 때 RECORD_NOT_FOUND 확인
- 존재하지 않는 commentId로 요청이 들어올 경우 COMMENT_NOT_FOUND 확인
- 회원 2로 회원 2가 남긴 댓글(commentId:2)을 삭제할 경우 대댓글(commentId:3,4)도 삭제 확인
- 회원 2가 회원 1이 남긴 댓글(commentId:1)을 삭제 요청할 경우 NO_AUTHORITY_ERROR 확인
- 회원 1이 회원 1이 남긴 댓글(commentId:1) 삭제 요청 시 삭제 확인
 
## TO-BE

- Record에 대한 좋아요 기능 구현

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 
