### PR TITLE
Kakao 주소 API > 주소 검색하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    implementation 'com.google.code.gson:gson:2.9.0'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 

--- a/src/main/java/com/anonymous/usports/domain/recruit/api/component/AddressConverter.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/api/component/AddressConverter.java
@@ -2,22 +2,14 @@ package com.anonymous.usports.domain.recruit.api.component;
 
 import com.anonymous.usports.domain.recruit.api.dto.AddressDto;
 import com.anonymous.usports.domain.recruit.api.dto.AddressResponse;
-import com.anonymous.usports.domain.recruit.api.dto.Document;
 import com.google.gson.Gson;
-import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import javax.print.Doc;
 import lombok.extern.slf4j.Slf4j;
-import net.bytebuddy.description.method.MethodDescription.TypeToken;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.BufferingClientHttpRequestFactory;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
@@ -42,7 +34,7 @@ public class AddressConverter {
 
     //HttpHeader
     HttpHeaders headers = new HttpHeaders();
-    headers.add("Authorization","KakaoAK " + kakaoApiKey);
+    headers.add("Authorization", "KakaoAK " + kakaoApiKey);
 
     HttpEntity<Object> httpEntity = new HttpEntity<>(null, headers);
 

--- a/src/main/java/com/anonymous/usports/domain/recruit/api/component/AddressConverter.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/api/component/AddressConverter.java
@@ -1,0 +1,59 @@
+package com.anonymous.usports.domain.recruit.api.component;
+
+import com.anonymous.usports.domain.recruit.api.dto.AddressDto;
+import com.anonymous.usports.domain.recruit.api.dto.AddressResponse;
+import com.anonymous.usports.domain.recruit.api.dto.Document;
+import com.google.gson.Gson;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import javax.print.Doc;
+import lombok.extern.slf4j.Slf4j;
+import net.bytebuddy.description.method.MethodDescription.TypeToken;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+public class AddressConverter {
+
+  @Value("${kakao.api_key}")
+  private String kakaoApiKey;
+
+  public AddressDto roadNameAddressToBuildingInfo(String roadNameAddress) {
+    String reqUrl = new StringBuilder()
+        .append("https://dapi.kakao.com/v2/local/search/address.json")
+        .append("?")
+        .append("query=").append(roadNameAddress).append("&")
+        .append("analyze_type=exact")
+        .toString();
+
+    RestTemplate rt = new RestTemplate();
+    rt.getMessageConverters().add(0, new StringHttpMessageConverter(StandardCharsets.UTF_8));
+
+    //HttpHeader
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization","KakaoAK " + kakaoApiKey);
+
+    HttpEntity<Object> httpEntity = new HttpEntity<>(null, headers);
+
+    ResponseEntity<String> response =
+        rt.exchange(reqUrl, HttpMethod.GET, httpEntity, String.class);
+    log.info(response.toString());
+    Gson gson = new Gson();
+    AddressResponse addressResponse = gson.fromJson(response.getBody(), AddressResponse.class);
+
+    log.info(addressResponse.toString());
+
+    return AddressDto.fromAddressResponse(addressResponse);
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/recruit/api/component/AddressConverter.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/api/component/AddressConverter.java
@@ -21,7 +21,7 @@ public class AddressConverter {
   @Value("${kakao.api_key}")
   private String kakaoApiKey;
 
-  public AddressDto roadNameAddressToBuildingInfo(String roadNameAddress) {
+  public AddressDto roadNameAddressToLocationInfo(String roadNameAddress) {
     String reqUrl = new StringBuilder()
         .append("https://dapi.kakao.com/v2/local/search/address.json")
         .append("?")

--- a/src/main/java/com/anonymous/usports/domain/recruit/api/dto/Address.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/api/dto/Address.java
@@ -1,0 +1,30 @@
+package com.anonymous.usports.domain.recruit.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class Address {
+
+  private String address_name; //전체 지번 주소
+  private String region_1depth_name;//지역 1 Depth, 시도 단위
+  private String region_2depth_name;//지역 2 Depth, 구 단위
+  private String region_3depth_name;//지역 3 Depth, 동 단위
+  private String region_3depth_h_name;//지역 3 Depth, 행정동 명칭
+  private String h_code;//행정 코드
+  private String b_code;//법정 코드
+  private String mountain_yn;//산 여부, Y 또는 N
+  private String main_address_no;//지번 주번지
+  private String sub_address_no;//지번 부번지, 없을 경우 빈 문자열("") 반환
+  private String x; //lnt - X 좌표값, 경위도인 경우 경도(longitude)
+  private String y; //lat - Y 좌표값, 경위도인 경우 위도(latitude)
+}

--- a/src/main/java/com/anonymous/usports/domain/recruit/api/dto/AddressDto.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/api/dto/AddressDto.java
@@ -1,0 +1,43 @@
+package com.anonymous.usports.domain.recruit.api.dto;
+import com.anonymous.usports.global.exception.ErrorCode;
+import com.anonymous.usports.global.exception.MyException;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AddressDto {
+
+  private String roadNameAddress;
+  private String roadNumberAddress;
+
+  private String lat;
+  private String lnt;
+  private String hCode;//행정 코드
+  private String bCode;//법정 코드
+
+
+  public static AddressDto fromAddressResponse(AddressResponse addressResponse){
+
+    try {
+      Document document = addressResponse.getDocuments().get(0);
+      return AddressDto.builder()
+          .roadNameAddress(document.getAddress_name())
+          .roadNumberAddress(document.getAddress().getAddress_name())
+          .lat(document.getY())
+          .lnt(document.getX())
+          .bCode(document.getAddress().getB_code())
+          .hCode(document.getAddress().getH_code())
+          .build();
+    }catch (Exception e){
+      throw new MyException(ErrorCode.ADDRESS_API_ERROR);
+    }
+  }
+
+}

--- a/src/main/java/com/anonymous/usports/domain/recruit/api/dto/AddressResponse.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/api/dto/AddressResponse.java
@@ -1,0 +1,28 @@
+package com.anonymous.usports.domain.recruit.api.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AddressResponse {
+
+  private Meta meta;
+  private List<Document> documents;
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("AddressResponse(meta=" + this.getMeta()).append("\n");
+    for(Document d : this.documents){
+      sb.append(d).append("\n");
+    }
+    return sb.toString();
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/recruit/api/dto/Document.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/api/dto/Document.java
@@ -1,0 +1,26 @@
+package com.anonymous.usports.domain.recruit.api.dto;
+
+import lombok.ToString;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class Document {
+
+  private String address_name;
+  private String address_type;
+  private String x; //lnt : 경도
+  private String y; //lat : 위도
+
+  private Address address;
+  private RoadAddress roadAddress;
+}

--- a/src/main/java/com/anonymous/usports/domain/recruit/api/dto/Meta.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/api/dto/Meta.java
@@ -1,0 +1,22 @@
+package com.anonymous.usports.domain.recruit.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class Meta {
+
+  private Integer total_count; //검색어에 검색된 문서 수
+  private Integer pageable_count; //total_count 중 노출 가능 문서 수(최대 : 45)
+  private Boolean is_end; //현제 페이지가 마지막 페이지인지 여부
+
+}

--- a/src/main/java/com/anonymous/usports/domain/recruit/api/dto/RoadAddress.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/api/dto/RoadAddress.java
@@ -1,0 +1,29 @@
+package com.anonymous.usports.domain.recruit.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class RoadAddress {
+  private String address_name; //전체 지번 주소
+  private String region_1depth_name;//지역명1
+  private String region_2depth_name;//지역명2
+  private String region_3depth_name;//지역명3
+  private String road_name; //도로명
+  private String underground_yn; //지하 여부, Y 또는 N
+  private String main_building_no; //건물 본번
+  private String sub_building_no; //건물 부번, 없을 경우 빈 문자열("") 반환
+  private String building_name; //건물 이름
+  private String zone_no; //우편번호(5자리)
+  private String x; //lnt - X 좌표값, 경위도인 경우 경도(longitude)
+  private String y; //lat - Y 좌표값, 경위도인 경우 위도(latitude)
+}

--- a/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
+++ b/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
@@ -63,6 +63,9 @@ public enum ErrorCode {
   SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우 할 수 없습니다."),
 
 
+  //기타
+  ADDRESS_API_ERROR(HttpStatus.BAD_REQUEST, "도로명 주소 입력값이 잘못되었습니다."),
+
   //BASIC
   NO_AUTHORITY_ERROR(HttpStatus.FORBIDDEN, "권한이 없습니다."),
   NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "404 NOT FOUND"),

--- a/src/test/java/com/anonymous/usports/test/AddressConverterApiTest.java
+++ b/src/test/java/com/anonymous/usports/test/AddressConverterApiTest.java
@@ -24,7 +24,7 @@ public class AddressConverterApiTest {
   @DisplayName("성공")
   void addressConverter() {
     String name = "전북 삼성동 100";
-    AddressDto addressDto = addressConverter.roadNameAddressToBuildingInfo(name);
+    AddressDto addressDto = addressConverter.roadNameAddressToLocationInfo(name);
     log.info(addressDto.toString());
   }
 
@@ -33,7 +33,7 @@ public class AddressConverterApiTest {
   void addressConverter_ADDRESS_API_ERROR() {
     String addr = "전남 삼!성!동! 1!0";
     try {
-      addressConverter.roadNameAddressToBuildingInfo(addr);
+      addressConverter.roadNameAddressToLocationInfo(addr);
     } catch (MyException e) {
       assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ADDRESS_API_ERROR);
     }

--- a/src/test/java/com/anonymous/usports/test/AddressConverterApiTest.java
+++ b/src/test/java/com/anonymous/usports/test/AddressConverterApiTest.java
@@ -1,0 +1,21 @@
+package com.anonymous.usports.test;
+
+
+import com.anonymous.usports.domain.recruit.api.component.AddressConverter;
+import com.anonymous.usports.domain.recruit.api.dto.AddressDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class AddressConverterApiTest {
+
+  @Autowired
+  private AddressConverter addressConverter;
+
+  @Test
+  void addressConverter(){
+    String name = "강동구 상암로 aa1";
+    AddressDto addressDto = addressConverter.roadNameAddressToBuildingInfo(name);
+  }
+}

--- a/src/test/java/com/anonymous/usports/test/AddressConverterApiTest.java
+++ b/src/test/java/com/anonymous/usports/test/AddressConverterApiTest.java
@@ -1,12 +1,19 @@
 package com.anonymous.usports.test;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.anonymous.usports.domain.recruit.api.component.AddressConverter;
 import com.anonymous.usports.domain.recruit.api.dto.AddressDto;
+import com.anonymous.usports.global.exception.ErrorCode;
+import com.anonymous.usports.global.exception.MyException;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@Slf4j
 @SpringBootTest
 public class AddressConverterApiTest {
 
@@ -14,8 +21,22 @@ public class AddressConverterApiTest {
   private AddressConverter addressConverter;
 
   @Test
-  void addressConverter(){
-    String name = "강동구 상암로 aa1";
+  @DisplayName("성공")
+  void addressConverter() {
+    String name = "전북 삼성동 100";
     AddressDto addressDto = addressConverter.roadNameAddressToBuildingInfo(name);
+    log.info(addressDto.toString());
+  }
+
+  @Test
+  @DisplayName("잘못된 주소 입력")
+  void addressConverter_ADDRESS_API_ERROR() {
+    String addr = "전남 삼!성!동! 1!0";
+    try {
+      addressConverter.roadNameAddressToBuildingInfo(addr);
+    } catch (MyException e) {
+      assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ADDRESS_API_ERROR);
+    }
+
   }
 }


### PR DESCRIPTION
### 개발 사항
FE 에서 다음 주소 API를 이용해 정확한 도로명 주소  String을 받는다. 
받은 문자열 roadNameAddress 를 
AddressConverter.roadNameAddressToLocationInfo(String roadNameAddress) 에 인수로 넣으면 
자세한 위치 정보 (건물코드, 위도, 경도 등)을 얻을 수 있음.

- AddressDto : AddressResponse중 필요한 부분만을 추출한 Dto , 이 Dto를 다른 서비스에서 사용할 예정
- AddressResponse : 최상위 객체
- Meta : 메타 데이터
- Document 
    - address_name : 전체 지번 주소 또는 도로명 주소
    - address_type : 주소 type (REGION, ROAD, REGION_ADDR, ROAD_ADDR)
    - x : lnt(경도)
    - y : lat(위도)
    - address : 주소 객체
    - roadAddress : 도로명 주소 상세 정보

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
