### PR TITLE
Feat: 기록에 대한 좋아요 기능 추가

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/RecordLike/controller/RecordLikeController.java
+++ b/src/main/java/com/anonymous/usports/domain/RecordLike/controller/RecordLikeController.java
@@ -1,0 +1,31 @@
+package com.anonymous.usports.domain.RecordLike.controller;
+
+import com.anonymous.usports.domain.RecordLike.dto.RecordLikeDto;
+import com.anonymous.usports.domain.RecordLike.service.RecordLikeService;
+import com.anonymous.usports.domain.member.dto.MemberDto;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class RecordLikeController {
+
+  private final RecordLikeService recordLikeService;
+
+  @ApiOperation("좋아요 신청/취소")
+  @PostMapping("/record/{recordId}/like")
+  public ResponseEntity<RecordLikeDto> switchLike(
+      @PathVariable Long recordId,
+      @AuthenticationPrincipal MemberDto loginMember
+  ) {
+    RecordLikeDto response = recordLikeService.switchLike(recordId, loginMember.getMemberId());
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/RecordLike/dto/RecordLikeDto.java
+++ b/src/main/java/com/anonymous/usports/domain/RecordLike/dto/RecordLikeDto.java
@@ -19,11 +19,12 @@ public class RecordLikeDto {
   private Long recordId;
   private String message;
 
-  public static RecordLikeDto fromEntity(RecordLikeEntity recordLikeEntity) {
+  public static RecordLikeDto fromEntity(RecordLikeEntity recordLikeEntity, String message) {
     return RecordLikeDto.builder()
         .recordLikeId(recordLikeEntity.getRecordLikeId())
         .memberId(recordLikeEntity.getMember().getMemberId())
         .recordId(recordLikeEntity.getRecord().getRecordId())
+        .message(message)
         .build();
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/RecordLike/dto/RecordLikeDto.java
+++ b/src/main/java/com/anonymous/usports/domain/RecordLike/dto/RecordLikeDto.java
@@ -1,0 +1,29 @@
+package com.anonymous.usports.domain.RecordLike.dto;
+
+import com.anonymous.usports.domain.RecordLike.entity.RecordLikeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecordLikeDto {
+
+  private Long recordLikeId;
+  private Long memberId;
+  private Long recordId;
+  private String message;
+
+  public static RecordLikeDto fromEntity(RecordLikeEntity recordLikeEntity) {
+    return RecordLikeDto.builder()
+        .recordLikeId(recordLikeEntity.getRecordLikeId())
+        .memberId(recordLikeEntity.getMember().getMemberId())
+        .recordId(recordLikeEntity.getRecord().getRecordId())
+        .build();
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/RecordLike/entity/RecordLikeEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/RecordLike/entity/RecordLikeEntity.java
@@ -1,0 +1,57 @@
+package com.anonymous.usports.domain.RecordLike.entity;
+
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.record.entity.RecordEntity;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity(name = "recordlike")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecordLikeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "recordlike_id", nullable = false)
+  private Long recordLikeId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private MemberEntity member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "record_id", nullable = false)
+  private RecordEntity record;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RecordLikeEntity that = (RecordLikeEntity) o;
+    return Objects.equals(recordLikeId, that.recordLikeId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(recordLikeId);
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/RecordLike/repository/RecordLikeRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/RecordLike/repository/RecordLikeRepository.java
@@ -1,0 +1,14 @@
+package com.anonymous.usports.domain.RecordLike.repository;
+
+import com.anonymous.usports.domain.RecordLike.entity.RecordLikeEntity;
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.record.entity.RecordEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecordLikeRepository extends JpaRepository<RecordLikeEntity, Long> {
+
+  RecordLikeEntity findByRecordAndMember(RecordEntity record, MemberEntity loginMember);
+
+}

--- a/src/main/java/com/anonymous/usports/domain/RecordLike/service/RecordLikeService.java
+++ b/src/main/java/com/anonymous/usports/domain/RecordLike/service/RecordLikeService.java
@@ -1,0 +1,8 @@
+package com.anonymous.usports.domain.RecordLike.service;
+
+import com.anonymous.usports.domain.RecordLike.dto.RecordLikeDto;
+
+public interface RecordLikeService {
+
+  RecordLikeDto switchLike(Long recordId, Long loginMemberId);
+}

--- a/src/main/java/com/anonymous/usports/domain/RecordLike/service/impl/RecordLikeServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/RecordLike/service/impl/RecordLikeServiceImpl.java
@@ -42,29 +42,25 @@ public class RecordLikeServiceImpl implements RecordLikeService {
       throw new RecordException(ErrorCode.SELF_LIKE_NOT_ALLOWED);
     }
     RecordLikeEntity like = recordLikeRepository.findByRecordAndMember(record, loginMember);
-    if(like==null) {
-      like = RecordLikeEntity.builder()
+    if(like == null) {
+      record.setCountRecordLikes(record.getCountRecordLikes()+1);
+      recordRepository.save(record);
+      RecordLikeEntity likeEntity = RecordLikeEntity.builder()
           .record(record)
           .member(loginMember)
           .build();
-      record.setCountRecordLikes(record.getCountRecordLikes()+1);
-      recordRepository.save(record);
-      RecordLikeEntity recordLike = recordLikeRepository.save(like);
-      RecordLikeDto recordLikeDto = RecordLikeDto.fromEntity(recordLike);
-      recordLikeDto.setMessage(ResponseConstant.LIKE_RECORD);
-
-      return recordLikeDto;
+      RecordLikeEntity recordLike = recordLikeRepository.save(likeEntity);
+      return RecordLikeDto.fromEntity(recordLike, ResponseConstant.LIKE_RECORD);
     }
     record.setCountRecordLikes(record.getCountRecordLikes()-1);
     recordRepository.save(record);
-    RecordLikeDto recordLikeDto = RecordLikeDto.builder()
+    recordLikeRepository.delete(like);
+    return RecordLikeDto.builder()
         .recordLikeId(like.getRecordLikeId())
         .recordId(recordId)
         .memberId(loginMemberId)
         .message(ResponseConstant.CANCEL_LIKE_RECORD)
         .build();
-    recordLikeRepository.delete(like);
 
-    return recordLikeDto;
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/RecordLike/service/impl/RecordLikeServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/RecordLike/service/impl/RecordLikeServiceImpl.java
@@ -1,0 +1,70 @@
+package com.anonymous.usports.domain.RecordLike.service.impl;
+
+import com.anonymous.usports.domain.RecordLike.dto.RecordLikeDto;
+import com.anonymous.usports.domain.RecordLike.entity.RecordLikeEntity;
+import com.anonymous.usports.domain.RecordLike.repository.RecordLikeRepository;
+import com.anonymous.usports.domain.RecordLike.service.RecordLikeService;
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.domain.record.entity.RecordEntity;
+import com.anonymous.usports.domain.record.repository.RecordRepository;
+import com.anonymous.usports.global.constant.ResponseConstant;
+import com.anonymous.usports.global.exception.ErrorCode;
+import com.anonymous.usports.global.exception.MemberException;
+import com.anonymous.usports.global.exception.RecordException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RecordLikeServiceImpl implements RecordLikeService {
+
+  private final RecordRepository recordRepository;
+  private final MemberRepository memberRepository;
+  private final RecordLikeRepository recordLikeRepository;
+
+  /**
+   * 좋아요 신청/취소
+   *
+   * @param recordId 좋아요 신청/취소 할 기록 Id
+   * @param loginMemberId 로그인 한 회원 Id
+   * @return LikeDto 형태로 반환
+   */
+  @Override
+  public RecordLikeDto switchLike(Long recordId, Long loginMemberId) {
+    MemberEntity loginMember = memberRepository.findById(loginMemberId)
+        .orElseThrow(()->new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+    RecordEntity record = recordRepository.findById(recordId)
+        .orElseThrow(()->new RecordException(ErrorCode.RECORD_NOT_FOUND));
+    if(record.getMember().getMemberId().equals(loginMemberId)){
+      throw new RecordException(ErrorCode.SELF_LIKE_NOT_ALLOWED);
+    }
+    RecordLikeEntity like = recordLikeRepository.findByRecordAndMember(record, loginMember);
+    if(like==null) {
+      like = RecordLikeEntity.builder()
+          .record(record)
+          .member(loginMember)
+          .build();
+      record.setCountRecordLikes(record.getCountRecordLikes()+1);
+      recordRepository.save(record);
+      RecordLikeEntity recordLike = recordLikeRepository.save(like);
+      RecordLikeDto recordLikeDto = RecordLikeDto.fromEntity(recordLike);
+      recordLikeDto.setMessage(ResponseConstant.LIKE_RECORD);
+
+      return recordLikeDto;
+    }
+    record.setCountRecordLikes(record.getCountRecordLikes()-1);
+    recordRepository.save(record);
+    RecordLikeDto recordLikeDto = RecordLikeDto.builder()
+        .recordLikeId(like.getRecordLikeId())
+        .recordId(recordId)
+        .memberId(loginMemberId)
+        .message(ResponseConstant.CANCEL_LIKE_RECORD)
+        .build();
+    recordLikeRepository.delete(like);
+
+    return recordLikeDto;
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/record/entity/RecordEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/record/entity/RecordEntity.java
@@ -10,6 +10,7 @@ import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -41,11 +42,11 @@ public class RecordEntity {
   @Column(name = "record_id", nullable = false)
   private Long recordId;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", nullable = false)
   private MemberEntity member;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "sports_id", nullable = false)
   private SportsEntity sports;
 
@@ -63,6 +64,10 @@ public class RecordEntity {
   @Column(name = "count_comment", nullable = false)
   @ColumnDefault("0")
   private Long countComment;
+
+  @Column(name = "count_recordlikes", nullable = false)
+  @ColumnDefault("0")
+  private Long countRecordLikes;
 
   @Convert(converter = StringListConverter.class)
   @Column(name = "image_address", columnDefinition = "TEXT")

--- a/src/main/java/com/anonymous/usports/global/constant/ResponseConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/ResponseConstant.java
@@ -40,4 +40,8 @@ public class ResponseConstant {
   public static final String CREATE_COMMENT = "댓글을 등록했습니다.";
   public static final String UPDATE_COMMENT = "댓글을 수정했습니다.";
   public static final String DELETE_COMMENT = "댓글을 삭제했습니다.";
+
+  // 좋아요 관련
+  public static final String LIKE_RECORD = "좋아요를 눌렀습니다.";
+  public static final String CANCEL_LIKE_RECORD = "좋아요를 취소했습니다.";
 }

--- a/src/main/java/com/anonymous/usports/global/constant/ResponseConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/ResponseConstant.java
@@ -42,6 +42,6 @@ public class ResponseConstant {
   public static final String DELETE_COMMENT = "댓글을 삭제했습니다.";
 
   // 좋아요 관련
-  public static final String LIKE_RECORD = "좋아요를 눌렀습니다.";
+  public static final String LIKE_RECORD = "좋아요를 신청했습니다.";
   public static final String CANCEL_LIKE_RECORD = "좋아요를 취소했습니다.";
 }

--- a/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
+++ b/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode {
   RECORD_DELETE_ERROR(HttpStatus.BAD_REQUEST,"기록 삭제 중 에러가 발생했습니다."),
   INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST,"업로드 할 수 없는 확장자입니다."),
   CANNOT_DELETE_RECORD_FOR_COMMENT(HttpStatus.BAD_REQUEST,"댓글이 있는 게시글은 삭제할 수 없습니다."),
+  SELF_LIKE_NOT_ALLOWED(HttpStatus.BAD_REQUEST,"자신의 기록을 좋아요 할 수 없습니다."),
 
   //Follow 관련
   FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND,"팔로우를 찾을 수 없습니다."),

--- a/src/test/java/com/anonymous/usports/domain/RecordLike/service/impl/RecordLikeServiceImplTest.java
+++ b/src/test/java/com/anonymous/usports/domain/RecordLike/service/impl/RecordLikeServiceImplTest.java
@@ -1,0 +1,210 @@
+package com.anonymous.usports.domain.RecordLike.service.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.anonymous.usports.domain.RecordLike.dto.RecordLikeDto;
+import com.anonymous.usports.domain.RecordLike.entity.RecordLikeEntity;
+import com.anonymous.usports.domain.RecordLike.repository.RecordLikeRepository;
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.domain.record.entity.RecordEntity;
+import com.anonymous.usports.domain.record.repository.RecordRepository;
+import com.anonymous.usports.domain.sports.entity.SportsEntity;
+import com.anonymous.usports.global.constant.ResponseConstant;
+import com.anonymous.usports.global.exception.ErrorCode;
+import com.anonymous.usports.global.exception.MemberException;
+import com.anonymous.usports.global.exception.RecordException;
+import com.anonymous.usports.global.type.Gender;
+import com.anonymous.usports.global.type.Role;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RecordLikeServiceImplTest {
+
+  @Mock
+  private RecordRepository recordRepository;
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @Mock
+  private RecordLikeRepository recordLikeRepository;
+
+  @InjectMocks
+  private RecordLikeServiceImpl recordLikeService;
+
+  private MemberEntity createMember(Long id) {
+    return MemberEntity.builder()
+        .memberId(id)
+        .accountName("testAccountName" + id)
+        .name("testName" + id)
+        .email("test@test" + id + ".com")
+        .password("password" + id)
+        .phoneNumber("010-1111-111" + id)
+        .birthDate(LocalDate.now())
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .profileOpen(true)
+        .build();
+  }
+  private SportsEntity createSports(Long id,String sportsName) {
+    return SportsEntity.builder()
+        .sportsId(id)
+        .sportsName(sportsName)
+        .build();
+  }
+
+  private RecordEntity createRecord(Long id, MemberEntity member, SportsEntity sports) {
+    List<String> images = new ArrayList<>();
+    for(int i=0; i<3;i++){
+      images.add("http://이미지주소"+id+".com");
+    }
+    return RecordEntity.builder()
+        .recordId(id)
+        .member(member)
+        .sports(sports)
+        .recordContent("테스트 기록 내용"+id)
+        .registeredAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .countComment(0L)
+        .imageAddress(images)
+        .countRecordLikes(0L)
+        .build();
+  }
+  private RecordLikeEntity createRecordLike(Long id, MemberEntity member, RecordEntity record) {
+    return RecordLikeEntity.builder()
+        .recordLikeId(id)
+        .record(record)
+        .member(member)
+        .build();
+  }
+
+  @Nested
+  @DisplayName("좋아요 신청/취소")
+  class switchLike {
+
+    @Test
+    @DisplayName("성공 - 좋아요 신청")
+    void success_LikeOn(){
+      MemberEntity member = createMember(1L);
+      MemberEntity otherMember = createMember(2L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L,otherMember,sports);
+      RecordLikeEntity recordLike = createRecordLike(1000L,member,record);
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+      when(recordLikeRepository.findByRecordAndMember(record,member))
+          .thenReturn(null);
+      when(recordLikeRepository.save(new RecordLikeEntity()))
+          .thenReturn(recordLike);
+
+      RecordLikeDto response = recordLikeService.switchLike(record.getRecordId(), member.getMemberId());
+
+      verify(recordLikeRepository,times(1)).save(new RecordLikeEntity());
+      verify(recordRepository,times(1)).save(record);
+
+      assertEquals(response.getRecordId(), record.getRecordId());
+      assertEquals(response.getMemberId(), member.getMemberId());
+      assertEquals(response.getMessage(), ResponseConstant.LIKE_RECORD);
+    }
+
+    @Test
+    @DisplayName("성공 - 좋아요 취소")
+    void success_LikeOff(){
+      MemberEntity member = createMember(1L);
+      MemberEntity otherMember = createMember(2L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L,otherMember,sports);
+      RecordLikeEntity recordLike = createRecordLike(1000L,member,record);
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+      when(recordLikeRepository.findByRecordAndMember(record,member))
+          .thenReturn(recordLike);
+
+      RecordLikeDto response = recordLikeService.switchLike(record.getRecordId(), member.getMemberId());
+
+      verify(recordLikeRepository,times(1)).delete(recordLike);
+      verify(recordRepository,times(1)).save(record);
+
+      assertEquals(response.getRecordId(), record.getRecordId());
+      assertEquals(response.getMemberId(), member.getMemberId());
+      assertEquals(response.getMessage(), ResponseConstant.CANCEL_LIKE_RECORD);
+    }
+    @Test
+    @DisplayName("실패 - MEMBER_NOT_FOUND")
+    void fail_MemberNotFound(){
+      MemberEntity member = createMember(1L);
+      MemberEntity otherMember = createMember(2L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L,otherMember,sports);
+      RecordLikeEntity recordLike = createRecordLike(1000L,member,record);
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.empty());
+
+      MemberException exception =
+          catchThrowableOfType(()->
+              recordLikeService.switchLike(record.getRecordId(),member.getMemberId()),
+              MemberException.class);
+      assertEquals(exception.getErrorCode(), ErrorCode.MEMBER_NOT_FOUND);
+    }
+    @Test
+    @DisplayName("실패 - RECORD_NOT_FOUND")
+    void fail_RecordNotFound(){
+      MemberEntity member = createMember(1L);
+      MemberEntity otherMember = createMember(2L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L,otherMember,sports);
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.empty());
+
+      RecordException exception =
+          catchThrowableOfType(()->
+                  recordLikeService.switchLike(record.getRecordId(),member.getMemberId()),
+              RecordException.class);
+      assertEquals(exception.getErrorCode(), ErrorCode.RECORD_NOT_FOUND);
+    }
+    @Test
+    @DisplayName("실패 - SELF_LIKE_NOT_ALLOWED")
+    void fail_SelfLikeNotAllowed(){
+      MemberEntity member = createMember(1L);
+      SportsEntity sports = createSports(10L,"축구");
+      RecordEntity record = createRecord(100L,member,sports);
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(recordRepository.findById(100L))
+          .thenReturn(Optional.of(record));
+
+      RecordException exception =
+          catchThrowableOfType(()->
+                  recordLikeService.switchLike(record.getRecordId(),member.getMemberId()),
+              RecordException.class);
+      assertEquals(exception.getErrorCode(), ErrorCode.SELF_LIKE_NOT_ALLOWED);
+    }
+  }
+}


### PR DESCRIPTION
# 변경사항

## AS-IS

### [추가된 기능]

**기록에 대한 좋아요 신청/취소 기능**

기존에 등록된 기록에 대한 '좋아요' 기능을 추가했습니다.
기존에 '좋아요' 정보가 있을 시 기존 정보를 삭제하는 방식으로 취소가 작동합니다.
recordEntity에 countRecordLikes 항목을 추가하여 '좋아요'가 등록될 시 +1, 취소될 시 -1이 됩니다.
자기 자신의 기록에 대한 '좋아요' 신청은 거절됩니다.


### [API 테스트 케이스]

Postman으로 진행했으며 회원 1,2와 record 1을 생성하여 진행했습니다.

- 없는 기록 Id로 '좋아요' 요청이 들어왔을 때 RECORD_NOT_FOUND 확인
- 자기 자신의 기록에 대한 '좋아요' 신청 시 SELF_LIKE_NOT_ALLOWED 확인
- 기존 '좋아요' 정보가 없을 경우 DB에 '좋아요' 정보가 입력되는 것을 확인('좋아요' 신청)
- 기존 '좋아요' 정보가 있을 경우 DB에 기존 '좋아요' 정보가 삭제되는 것을 확인('좋아요' 취소)
- '좋아요' 신청과 취소 시 record의 count_recordlike 항목이 각각 +1 / -1되는 것을 확인


## TO-BE

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

