### PR TITLE
Refactor: RecordLike 관련 리팩토링

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/RecordLike/service/RecordLikeService.java
+++ b/src/main/java/com/anonymous/usports/domain/RecordLike/service/RecordLikeService.java
@@ -1,8 +1,0 @@
-package com.anonymous.usports.domain.RecordLike.service;
-
-import com.anonymous.usports.domain.RecordLike.dto.RecordLikeDto;
-
-public interface RecordLikeService {
-
-  RecordLikeDto switchLike(Long recordId, Long loginMemberId);
-}

--- a/src/main/java/com/anonymous/usports/domain/recordlike/controller/RecordLikeController.java
+++ b/src/main/java/com/anonymous/usports/domain/recordlike/controller/RecordLikeController.java
@@ -1,8 +1,8 @@
-package com.anonymous.usports.domain.RecordLike.controller;
+package com.anonymous.usports.domain.recordlike.controller;
 
-import com.anonymous.usports.domain.RecordLike.dto.RecordLikeDto;
-import com.anonymous.usports.domain.RecordLike.service.RecordLikeService;
 import com.anonymous.usports.domain.member.dto.MemberDto;
+import com.anonymous.usports.domain.recordlike.dto.RecordLikeDto;
+import com.anonymous.usports.domain.recordlike.service.RecordLikeService;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,11 +21,12 @@ public class RecordLikeController {
 
   @ApiOperation("좋아요 신청/취소")
   @PostMapping("/record/{recordId}/like")
-  public ResponseEntity<RecordLikeDto> switchLike(
+  public ResponseEntity<RecordLikeDto> switchLikeOrCancel(
       @PathVariable Long recordId,
       @AuthenticationPrincipal MemberDto loginMember
   ) {
-    RecordLikeDto response = recordLikeService.switchLike(recordId, loginMember.getMemberId());
+    RecordLikeDto response = recordLikeService.switchLikeOrCancel(recordId,
+        loginMember.getMemberId());
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/recordlike/dto/RecordLikeDto.java
+++ b/src/main/java/com/anonymous/usports/domain/recordlike/dto/RecordLikeDto.java
@@ -1,6 +1,6 @@
-package com.anonymous.usports.domain.RecordLike.dto;
+package com.anonymous.usports.domain.recordlike.dto;
 
-import com.anonymous.usports.domain.RecordLike.entity.RecordLikeEntity;
+import com.anonymous.usports.domain.recordlike.entity.RecordLikeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/anonymous/usports/domain/recordlike/entity/RecordLikeEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/recordlike/entity/RecordLikeEntity.java
@@ -1,4 +1,4 @@
-package com.anonymous.usports.domain.RecordLike.entity;
+package com.anonymous.usports.domain.recordlike.entity;
 
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.record.entity.RecordEntity;
@@ -17,7 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Entity(name = "recordlike")
+@Entity(name = "record_like")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -27,7 +27,7 @@ public class RecordLikeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "recordlike_id", nullable = false)
+  @Column(name = "record_like_id", nullable = false)
   private Long recordLikeId;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/anonymous/usports/domain/recordlike/repository/RecordLikeRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/recordlike/repository/RecordLikeRepository.java
@@ -1,14 +1,15 @@
-package com.anonymous.usports.domain.RecordLike.repository;
+package com.anonymous.usports.domain.recordlike.repository;
 
-import com.anonymous.usports.domain.RecordLike.entity.RecordLikeEntity;
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.record.entity.RecordEntity;
+import com.anonymous.usports.domain.recordlike.entity.RecordLikeEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecordLikeRepository extends JpaRepository<RecordLikeEntity, Long> {
 
-  RecordLikeEntity findByRecordAndMember(RecordEntity record, MemberEntity loginMember);
+  Optional<RecordLikeEntity> findByRecordAndMember(RecordEntity record, MemberEntity loginMember);
 
 }

--- a/src/main/java/com/anonymous/usports/domain/recordlike/service/RecordLikeService.java
+++ b/src/main/java/com/anonymous/usports/domain/recordlike/service/RecordLikeService.java
@@ -1,0 +1,8 @@
+package com.anonymous.usports.domain.recordlike.service;
+
+import com.anonymous.usports.domain.recordlike.dto.RecordLikeDto;
+
+public interface RecordLikeService {
+
+  RecordLikeDto switchLikeOrCancel(Long recordId, Long loginMemberId);
+}

--- a/src/main/java/com/anonymous/usports/domain/recordlike/service/impl/RecordLikeServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/recordlike/service/impl/RecordLikeServiceImpl.java
@@ -1,17 +1,18 @@
-package com.anonymous.usports.domain.RecordLike.service.impl;
+package com.anonymous.usports.domain.recordlike.service.impl;
 
-import com.anonymous.usports.domain.RecordLike.dto.RecordLikeDto;
-import com.anonymous.usports.domain.RecordLike.entity.RecordLikeEntity;
-import com.anonymous.usports.domain.RecordLike.repository.RecordLikeRepository;
-import com.anonymous.usports.domain.RecordLike.service.RecordLikeService;
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.member.repository.MemberRepository;
 import com.anonymous.usports.domain.record.entity.RecordEntity;
 import com.anonymous.usports.domain.record.repository.RecordRepository;
+import com.anonymous.usports.domain.recordlike.dto.RecordLikeDto;
+import com.anonymous.usports.domain.recordlike.entity.RecordLikeEntity;
+import com.anonymous.usports.domain.recordlike.repository.RecordLikeRepository;
+import com.anonymous.usports.domain.recordlike.service.RecordLikeService;
 import com.anonymous.usports.global.constant.ResponseConstant;
 import com.anonymous.usports.global.exception.ErrorCode;
 import com.anonymous.usports.global.exception.MemberException;
 import com.anonymous.usports.global.exception.RecordException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,22 +29,23 @@ public class RecordLikeServiceImpl implements RecordLikeService {
   /**
    * 좋아요 신청/취소
    *
-   * @param recordId 좋아요 신청/취소 할 기록 Id
+   * @param recordId      좋아요 신청/취소 할 기록 Id
    * @param loginMemberId 로그인 한 회원 Id
    * @return LikeDto 형태로 반환
    */
   @Override
-  public RecordLikeDto switchLike(Long recordId, Long loginMemberId) {
+  public RecordLikeDto switchLikeOrCancel(Long recordId, Long loginMemberId) {
     MemberEntity loginMember = memberRepository.findById(loginMemberId)
-        .orElseThrow(()->new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
     RecordEntity record = recordRepository.findById(recordId)
-        .orElseThrow(()->new RecordException(ErrorCode.RECORD_NOT_FOUND));
-    if(record.getMember().getMemberId().equals(loginMemberId)){
+        .orElseThrow(() -> new RecordException(ErrorCode.RECORD_NOT_FOUND));
+    if (record.getMember().getMemberId().equals(loginMemberId)) {
       throw new RecordException(ErrorCode.SELF_LIKE_NOT_ALLOWED);
     }
-    RecordLikeEntity like = recordLikeRepository.findByRecordAndMember(record, loginMember);
-    if(like == null) {
-      record.setCountRecordLikes(record.getCountRecordLikes()+1);
+    Optional<RecordLikeEntity> like = recordLikeRepository.findByRecordAndMember(record,
+        loginMember);
+    if (!like.isPresent()) {
+      record.setCountRecordLikes(record.getCountRecordLikes() + 1);
       recordRepository.save(record);
       RecordLikeEntity likeEntity = RecordLikeEntity.builder()
           .record(record)
@@ -52,11 +54,11 @@ public class RecordLikeServiceImpl implements RecordLikeService {
       RecordLikeEntity recordLike = recordLikeRepository.save(likeEntity);
       return RecordLikeDto.fromEntity(recordLike, ResponseConstant.LIKE_RECORD);
     }
-    record.setCountRecordLikes(record.getCountRecordLikes()-1);
+    record.setCountRecordLikes(record.getCountRecordLikes() - 1);
     recordRepository.save(record);
-    recordLikeRepository.delete(like);
+    recordLikeRepository.delete(like.get());
     return RecordLikeDto.builder()
-        .recordLikeId(like.getRecordLikeId())
+        .recordLikeId(like.get().getRecordLikeId())
         .recordId(recordId)
         .memberId(loginMemberId)
         .message(ResponseConstant.CANCEL_LIKE_RECORD)

--- a/src/test/java/com/anonymous/usports/domain/recordlike/service/impl/RecordLikeServiceImplTest.java
+++ b/src/test/java/com/anonymous/usports/domain/recordlike/service/impl/RecordLikeServiceImplTest.java
@@ -1,4 +1,4 @@
-package com.anonymous.usports.domain.RecordLike.service.impl;
+package com.anonymous.usports.domain.recordlike.service.impl;
 
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType;
 import static org.junit.jupiter.api.Assertions.*;
@@ -6,9 +6,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.anonymous.usports.domain.RecordLike.dto.RecordLikeDto;
-import com.anonymous.usports.domain.RecordLike.entity.RecordLikeEntity;
-import com.anonymous.usports.domain.RecordLike.repository.RecordLikeRepository;
+import com.anonymous.usports.domain.recordlike.dto.RecordLikeDto;
+import com.anonymous.usports.domain.recordlike.entity.RecordLikeEntity;
+import com.anonymous.usports.domain.recordlike.repository.RecordLikeRepository;
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.member.repository.MemberRepository;
 import com.anonymous.usports.domain.record.entity.RecordEntity;
@@ -112,11 +112,11 @@ class RecordLikeServiceImplTest {
       when(recordRepository.findById(100L))
           .thenReturn(Optional.of(record));
       when(recordLikeRepository.findByRecordAndMember(record,member))
-          .thenReturn(null);
+          .thenReturn(Optional.empty());
       when(recordLikeRepository.save(new RecordLikeEntity()))
           .thenReturn(recordLike);
 
-      RecordLikeDto response = recordLikeService.switchLike(record.getRecordId(), member.getMemberId());
+      RecordLikeDto response = recordLikeService.switchLikeOrCancel(record.getRecordId(), member.getMemberId());
 
       verify(recordLikeRepository,times(1)).save(new RecordLikeEntity());
       verify(recordRepository,times(1)).save(record);
@@ -140,9 +140,9 @@ class RecordLikeServiceImplTest {
       when(recordRepository.findById(100L))
           .thenReturn(Optional.of(record));
       when(recordLikeRepository.findByRecordAndMember(record,member))
-          .thenReturn(recordLike);
+          .thenReturn(Optional.of(recordLike));
 
-      RecordLikeDto response = recordLikeService.switchLike(record.getRecordId(), member.getMemberId());
+      RecordLikeDto response = recordLikeService.switchLikeOrCancel(record.getRecordId(), member.getMemberId());
 
       verify(recordLikeRepository,times(1)).delete(recordLike);
       verify(recordRepository,times(1)).save(record);
@@ -158,14 +158,13 @@ class RecordLikeServiceImplTest {
       MemberEntity otherMember = createMember(2L);
       SportsEntity sports = createSports(10L,"축구");
       RecordEntity record = createRecord(100L,otherMember,sports);
-      RecordLikeEntity recordLike = createRecordLike(1000L,member,record);
 
       when(memberRepository.findById(1L))
           .thenReturn(Optional.empty());
 
       MemberException exception =
           catchThrowableOfType(()->
-              recordLikeService.switchLike(record.getRecordId(),member.getMemberId()),
+              recordLikeService.switchLikeOrCancel(record.getRecordId(),member.getMemberId()),
               MemberException.class);
       assertEquals(exception.getErrorCode(), ErrorCode.MEMBER_NOT_FOUND);
     }
@@ -184,7 +183,7 @@ class RecordLikeServiceImplTest {
 
       RecordException exception =
           catchThrowableOfType(()->
-                  recordLikeService.switchLike(record.getRecordId(),member.getMemberId()),
+                  recordLikeService.switchLikeOrCancel(record.getRecordId(),member.getMemberId()),
               RecordException.class);
       assertEquals(exception.getErrorCode(), ErrorCode.RECORD_NOT_FOUND);
     }
@@ -202,7 +201,7 @@ class RecordLikeServiceImplTest {
 
       RecordException exception =
           catchThrowableOfType(()->
-                  recordLikeService.switchLike(record.getRecordId(),member.getMemberId()),
+                  recordLikeService.switchLikeOrCancel(record.getRecordId(),member.getMemberId()),
               RecordException.class);
       assertEquals(exception.getErrorCode(), ErrorCode.SELF_LIKE_NOT_ALLOWED);
     }


### PR DESCRIPTION
### 변경사항

**AS-IS**

오전에 코멘트 받았던 사항들 수정했습니다. 
이 부분은 앞서 있었던 PR과 비교해서 명칭 제외 크게 바뀐 부분이 없으므로 구체적인 테스트 설명은 생략하겠습니다.

- switchLike 명칭 switchLikeOrCancel로 변경
- 엔티티명 recordlike에서 record_like로 변경
- findByRecordAndMember RecordLikeEntity에서 Optional<RecordLikeEntity>로 변경
- 패키지 RecordLike에서 recordlike로 변경

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

