### PR TITLE
Feature/record

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/dto/CommentDto.java
@@ -19,6 +19,12 @@ public class CommentDto {
 
   private Long memberId;
 
+  private String accountName;
+
+  private String name;
+
+  private String profileImage;
+
   private Long recordId;
 
   private String content;
@@ -33,6 +39,9 @@ public class CommentDto {
     return CommentDto.builder()
         .commentId(commentEntity.getCommentId())
         .memberId(commentEntity.getMember().getMemberId())
+        .accountName(commentEntity.getMember().getAccountName())
+        .name(commentEntity.getMember().getName())
+        .profileImage(commentEntity.getMember().getProfileImage())
         .recordId(commentEntity.getRecord().getRecordId())
         .content(commentEntity.getContent())
         .registerAt(commentEntity.getRegisteredAt())

--- a/src/main/java/com/anonymous/usports/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/repository/CommentRepository.java
@@ -3,7 +3,11 @@ package com.anonymous.usports.domain.comment.repository;
 import com.anonymous.usports.domain.comment.entity.CommentEntity;
 import com.anonymous.usports.domain.record.entity.RecordEntity;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,7 +16,10 @@ public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
 
   boolean existsByCommentId(Long commentId);
 
-  boolean existsByRecord(RecordEntity recordEntity);
+  @Query("SELECT c FROM comment c " +
+      "WHERE c.record.recordId = :recordId " +
+      "ORDER BY COALESCE(c.parentId, c.commentId), c.registeredAt ASC")
+  Page<CommentEntity> findAllCommentsByRecordId(@Param("recordId") Long recordId, Pageable pageable);
 
 
 

--- a/src/main/java/com/anonymous/usports/domain/record/controller/RecordController.java
+++ b/src/main/java/com/anonymous/usports/domain/record/controller/RecordController.java
@@ -80,4 +80,21 @@ public class RecordController {
     return ResponseEntity.ok(new RecordUpdate.Response(updateRecord));
   }
 
+  @ApiOperation("기록 수정 페이지 불러오기")
+  @GetMapping("/record/{recordId}/manage")
+  public ResponseEntity<RecordDto> getRecordUpdatePage(@PathVariable Long recordId,
+      @AuthenticationPrincipal MemberDto loginMember) {
+    RecordDto recordDto = recordService.getRecordUpdatePage(recordId, loginMember.getMemberId());
+    return ResponseEntity.ok(recordDto);
+  }
+
+  @ApiOperation("기록 상세 페이지")
+  @GetMapping("/record/{recordId}")
+  public ResponseEntity<RecordDto> getRecordDetail(@PathVariable Long recordId,
+      @AuthenticationPrincipal MemberDto loginMember,
+      @RequestParam(value = "page",defaultValue = "1") int page) {
+    RecordDto recordDetail = recordService.getRecordDetail(recordId, loginMember.getMemberId(), page);
+    return ResponseEntity.ok(recordDetail);
+  }
+
 }

--- a/src/main/java/com/anonymous/usports/domain/record/controller/RecordController.java
+++ b/src/main/java/com/anonymous/usports/domain/record/controller/RecordController.java
@@ -42,7 +42,7 @@ public class RecordController {
   @GetMapping("/home")
   public ResponseEntity<RecordListDto> getRecordList(
       @RequestParam(value = "type", defaultValue = "RECOMMENDATION") RecordType recordType,
-      @RequestParam("page") int page,
+      @RequestParam(value = "page",defaultValue = "1") int page,
       @AuthenticationPrincipal MemberDto loginMember) {
     RecordListDto records = recordService.getRecordsPage(recordType, page,
         loginMember.getMemberId());

--- a/src/main/java/com/anonymous/usports/domain/record/dto/RecordDto.java
+++ b/src/main/java/com/anonymous/usports/domain/record/dto/RecordDto.java
@@ -1,13 +1,17 @@
 package com.anonymous.usports.domain.record.dto;
 
+import com.anonymous.usports.domain.comment.dto.CommentDto;
+import com.anonymous.usports.domain.comment.entity.CommentEntity;
 import com.anonymous.usports.domain.record.entity.RecordEntity;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.domain.Page;
 
 @Getter
 @Setter
@@ -38,6 +42,8 @@ public class RecordDto {
 
   private List<String> imageAddressList;
 
+  private List<CommentDto> commentList;
+
 
   public static RecordDto fromEntity(RecordEntity recordEntity) {
     return RecordDto.builder()
@@ -52,6 +58,24 @@ public class RecordDto {
         .updatedAt(recordEntity.getUpdatedAt())
         .countComment(recordEntity.getCountComment())
         .imageAddressList(recordEntity.getImageAddress())
+        .build();
+  }
+
+  public static RecordDto fromEntityInclueComment(RecordEntity recordEntity, Page<CommentEntity> commentList) {
+    return RecordDto.builder()
+        .recordId(recordEntity.getRecordId())
+        .memberId(recordEntity.getMember().getMemberId())
+        .sportsId(recordEntity.getSports().getSportsId())
+        .accountName(recordEntity.getMember().getAccountName())
+        .name(recordEntity.getMember().getName())
+        .profileImage(recordEntity.getMember().getProfileImage())
+        .recordContent(recordEntity.getRecordContent())
+        .registeredAt(recordEntity.getRegisteredAt())
+        .updatedAt(recordEntity.getUpdatedAt())
+        .countComment(recordEntity.getCountComment())
+        .imageAddressList(recordEntity.getImageAddress())
+        .commentList(commentList.getContent().stream().map(CommentDto::fromEntity).collect(
+            Collectors.toList()))
         .build();
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/record/dto/RecordDto.java
+++ b/src/main/java/com/anonymous/usports/domain/record/dto/RecordDto.java
@@ -24,6 +24,8 @@ public class RecordDto {
 
   private String accountName;
 
+  private String name;
+
   private String recordContent;
 
   private LocalDateTime registeredAt;
@@ -31,6 +33,8 @@ public class RecordDto {
   private LocalDateTime updatedAt;
 
   private Long countComment;
+
+  private String profileImage;
 
   private List<String> imageAddressList;
 
@@ -41,6 +45,8 @@ public class RecordDto {
         .memberId(recordEntity.getMember().getMemberId())
         .sportsId(recordEntity.getSports().getSportsId())
         .accountName(recordEntity.getMember().getAccountName())
+        .name(recordEntity.getMember().getName())
+        .profileImage(recordEntity.getMember().getProfileImage())
         .recordContent(recordEntity.getRecordContent())
         .registeredAt(recordEntity.getRegisteredAt())
         .updatedAt(recordEntity.getUpdatedAt())

--- a/src/main/java/com/anonymous/usports/domain/record/entity/RecordEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/record/entity/RecordEntity.java
@@ -70,6 +70,7 @@ public class RecordEntity {
   private Long countRecordLikes;
 
   @Convert(converter = StringListConverter.class)
+  @Builder.Default
   @Column(name = "image_address", columnDefinition = "TEXT")
   private List<String> imageAddress = new ArrayList<>();
 

--- a/src/main/java/com/anonymous/usports/domain/record/service/RecordService.java
+++ b/src/main/java/com/anonymous/usports/domain/record/service/RecordService.java
@@ -21,6 +21,14 @@ public interface RecordService {
    */
   RecordListDto getRecordsPage(RecordType recordType, int page, Long loginMemberId);
 
+  /**
+   * 기록 게시글 수정 페이지
+   */
+  RecordDto getRecordUpdatePage(Long recordId, Long loginMemberId);
+
+  /**
+   * 기록 게시글 수정
+   */
   RecordDto updateRecord(Long recordId, RecordUpdate.Request request, Long loginMemberId);
 
   /**
@@ -28,4 +36,8 @@ public interface RecordService {
    */
   RecordDto deleteRecord(Long recordId, Long loginMemberId);
 
+  /**
+   * 기록 게시글 상세 페이지
+   */
+  RecordDto getRecordDetail(Long recordId, Long loginMemberId, int page);
 }

--- a/src/main/java/com/anonymous/usports/global/constant/NumberConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/NumberConstant.java
@@ -5,4 +5,6 @@ public class NumberConstant {
 
   public static final int PAGE_SIZE_DEFAULT = 10;
 
+  public static final int COMMENT_PAGE_SIZE_DEFAULT = 20;
+
 }


### PR DESCRIPTION
# 변경사항

## AS-IS

### [단순 리팩토링]
1. @RequestParam("page")에 defaultValue 추가
2. RecordDto에 name와 profileImage 추가
3. RecordEntity에 imageAddress 필드에 @Builder.Default 추가
4. Record 상세 페이지와 관련하여 CommentDto에 profileImage 추가
5. RecordDto에 Page<CommentEntity>를 추가한 fromEntity 메서드 생성

### [기능 추가]
1. Record 수정 페이지를 불러올 때에 기존 Record의 정보가 필요하기에 Record 정보를 가져오도록 만들었습니다.("/record/{recordId}/manage")
2. Record 상세 페이지에서 해당 Record 관련 정보와 그 Record에 달린 댓글을 확인할 수 있도록 했습니다.("/record/{recordId}")


### [API 테스트]

1. 기록 게시글에 댓글과 대댓글 달았을 때 댓글의 정렬 순서 확인(댓글 - 연관 대댓글 - 댓글 순서, 동일 항목 내에서는 registeredAt 오름차순으로 정렬)
2. 권한 없는 사용자의 수정 페이지 접근 시 NO_AUTHORITY_ERROR 확인

## TO-BE

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 

