### PR TITLE
Profile page

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/member/repository/MemberRepository.java
@@ -15,4 +15,7 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
     Optional<MemberEntity> findByEmail(String email);
 
+    Optional<MemberEntity> findByAccountName(String accountName);
+
+
 }

--- a/src/main/java/com/anonymous/usports/domain/member/security/SecurityConfig.java
+++ b/src/main/java/com/anonymous/usports/domain/member/security/SecurityConfig.java
@@ -56,7 +56,6 @@ public class SecurityConfig {
     public AuthenticationManager authenticationManagerBean(
             AuthenticationConfiguration authenticationConfiguration) throws Exception {
         return authenticationConfiguration.getAuthenticationManager();
-    }
-
+    } 
 
 }

--- a/src/main/java/com/anonymous/usports/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/controller/MyPageController.java
@@ -21,7 +21,7 @@ public class MyPageController {
   @ApiOperation("마이 페이지")
   @GetMapping("/mypage")
   public ResponseEntity<MyPageMainDto> myPage(@AuthenticationPrincipal MemberDto loginMember){
-    MyPageMainDto myPageMainData = myPageService.getMyPageMainData(1L);
+    MyPageMainDto myPageMainData = myPageService.getMyPageMainData(loginMember.getMemberId());
     return ResponseEntity.ok(myPageMainData);
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/controller/MyPageController.java
@@ -3,6 +3,7 @@ package com.anonymous.usports.domain.mypage.controller;
 import com.anonymous.usports.domain.member.dto.MemberDto;
 import com.anonymous.usports.domain.mypage.dto.MyPageMainDto;
 import com.anonymous.usports.domain.mypage.service.MyPageService;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ public class MyPageController {
 
   private final MyPageService myPageService;
 
+  @ApiOperation("마이 페이지")
   @GetMapping("/mypage")
   public ResponseEntity<MyPageMainDto> myPage(@AuthenticationPrincipal MemberDto loginMember){
     MyPageMainDto myPageMainData = myPageService.getMyPageMainData(1L);

--- a/src/main/java/com/anonymous/usports/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/service/MyPageService.java
@@ -1,8 +1,16 @@
 package com.anonymous.usports.domain.mypage.service;
 
+import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.mypage.dto.MyPageMainDto;
+import com.anonymous.usports.domain.mypage.dto.MyPageMember;
+import com.anonymous.usports.domain.sportsskill.dto.SportsSkillDto;
+import java.util.List;
 
 public interface MyPageService {
 
   MyPageMainDto getMyPageMainData(Long memberId);
+
+  MyPageMember getMyPageMember(MemberEntity member);
+
+  List<SportsSkillDto> getSportsSkills(MemberEntity member);
 }

--- a/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
@@ -165,8 +165,6 @@ public class MyPageServiceImpl implements MyPageService {
 
       list.add(new MyPageParticipant(participant));
     }
-
-
     return list;
   }
 

--- a/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
@@ -74,6 +74,7 @@ public class MyPageServiceImpl implements MyPageService {
         .build();
   }
 
+  @Override
   public MyPageMember getMyPageMember(MemberEntity member) {
     List<InterestedSportsEntity> interestedSportsEntityList =
         interestedSportsRepository.findAllByMemberEntity(member);
@@ -110,6 +111,7 @@ public class MyPageServiceImpl implements MyPageService {
   /**
    * 팝업으로 띄워줄 sportSkill
    */
+  @Override
   public List<SportsSkillDto> getSportsSkills(MemberEntity member) {
     return sportsSkillRepository.findAllByMember(member)
         .stream()

--- a/src/main/java/com/anonymous/usports/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/repository/ParticipantRepository.java
@@ -30,5 +30,10 @@ public interface ParticipantRepository extends JpaRepository<ParticipantEntity, 
 
   List<ParticipantEntity> findAllByRecruitAndStatus(RecruitEntity recruit, ParticipantStatus status);
 
-  List<ParticipantEntity> findTop10ByMemberOrderByRegisteredAtDesc(MemberEntity member);
+  Page<ParticipantEntity> findByMemberAndStatusAndMeetingDateBefore(
+      MemberEntity member,
+      ParticipantStatus participantStatus,
+      LocalDateTime localDateTime,
+      Pageable pageable);
+
 }

--- a/src/main/java/com/anonymous/usports/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/controller/ProfileController.java
@@ -1,0 +1,43 @@
+package com.anonymous.usports.domain.profile.controller;
+
+import com.anonymous.usports.domain.profile.dto.ProfileRecords;
+import com.anonymous.usports.domain.profile.dto.ProfileRecruits;
+import com.anonymous.usports.domain.profile.service.ProfileService;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class ProfileController {
+
+  private final ProfileService profileService;
+
+  @ApiOperation("프로필 - 기록 글")
+  @GetMapping("/{accountName}/records")
+  public ResponseEntity<ProfileRecords> profileRecords(@PathVariable String accountName,
+      @RequestParam(value = "page", defaultValue = "1") Integer page) {
+
+    ProfileRecords profileRecords = profileService.profileRecords(accountName, page);
+
+    return ResponseEntity.ok(profileRecords);
+  }
+
+
+  @ApiOperation("프로필 - 모집 글")
+  @GetMapping("/{accountName}/recruits")
+  public ResponseEntity<ProfileRecruits> profileRecruits(@PathVariable String accountName,
+      @RequestParam(value = "page", defaultValue = "1") Integer page) {
+
+    ProfileRecruits profileRecruits = profileService.profileRecruits(accountName, page);
+
+    return ResponseEntity.ok(profileRecruits);
+  }
+
+}

--- a/src/main/java/com/anonymous/usports/domain/profile/dto/ProfileRecords.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/dto/ProfileRecords.java
@@ -1,0 +1,27 @@
+package com.anonymous.usports.domain.profile.dto;
+
+import com.anonymous.usports.domain.mypage.dto.MyPageMember;
+import com.anonymous.usports.domain.record.dto.RecordListDto;
+import com.anonymous.usports.domain.sportsskill.dto.SportsSkillDto;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ProfileRecords {
+
+  private MyPageMember memberProfile;
+
+  private List<SportsSkillDto> sportsSkills;
+
+  private RecordListDto recordList;
+
+}

--- a/src/main/java/com/anonymous/usports/domain/profile/dto/ProfileRecruits.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/dto/ProfileRecruits.java
@@ -1,0 +1,25 @@
+package com.anonymous.usports.domain.profile.dto;
+
+import com.anonymous.usports.domain.mypage.dto.MyPageMember;
+import com.anonymous.usports.domain.recruit.dto.RecruitListDto;
+import com.anonymous.usports.domain.sportsskill.dto.SportsSkillDto;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ProfileRecruits {
+
+  private MyPageMember myPageMember;
+
+  private List<SportsSkillDto> sportsSkills;
+
+  private RecruitListDto recruitList;
+}

--- a/src/main/java/com/anonymous/usports/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/service/ProfileService.java
@@ -1,0 +1,12 @@
+package com.anonymous.usports.domain.profile.service;
+
+
+import com.anonymous.usports.domain.profile.dto.ProfileRecords;
+import com.anonymous.usports.domain.profile.dto.ProfileRecruits;
+
+public interface ProfileService {
+
+  ProfileRecords profileRecords(String accountName, Integer page);
+
+  ProfileRecruits profileRecruits(String accountName, Integer page);
+}

--- a/src/main/java/com/anonymous/usports/domain/profile/service/impl/ProfileServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/service/impl/ProfileServiceImpl.java
@@ -1,11 +1,30 @@
 package com.anonymous.usports.domain.profile.service.impl;
 
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.member.repository.MemberRepository;
 import com.anonymous.usports.domain.mypage.service.MyPageService;
+import com.anonymous.usports.domain.participant.entity.ParticipantEntity;
+import com.anonymous.usports.domain.participant.repository.ParticipantRepository;
 import com.anonymous.usports.domain.profile.dto.ProfileRecords;
 import com.anonymous.usports.domain.profile.dto.ProfileRecruits;
 import com.anonymous.usports.domain.profile.service.ProfileService;
+import com.anonymous.usports.domain.record.dto.RecordListDto;
+import com.anonymous.usports.domain.record.entity.RecordEntity;
+import com.anonymous.usports.domain.record.repository.RecordRepository;
+import com.anonymous.usports.domain.recruit.dto.RecruitListDto;
+import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
+import com.anonymous.usports.global.constant.NumberConstant;
+import com.anonymous.usports.global.exception.ErrorCode;
+import com.anonymous.usports.global.exception.MemberException;
+import com.anonymous.usports.global.type.ParticipantStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -14,16 +33,47 @@ import org.springframework.stereotype.Service;
 public class ProfileServiceImpl implements ProfileService {
 
   private final MyPageService myPageService;
+  private final MemberRepository memberRepository;
+  private final RecordRepository recordRepository;
+  private final ParticipantRepository participantRepository;
 
   @Override
   public ProfileRecords profileRecords(String accountName, Integer page) {
-    
-    return null;
+    MemberEntity member = memberRepository.findByAccountName(accountName)
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+    Page<RecordEntity> recordEntityPage = recordRepository
+        .findByMemberOrderByRegisteredAtDesc(
+            member, PageRequest.of(page - 1, NumberConstant.PAGE_SIZE_PROFILE));
+
+    return ProfileRecords.builder()
+        .memberProfile(myPageService.getMyPageMember(member))
+        .sportsSkills(myPageService.getSportsSkills(member))
+        .recordList(new RecordListDto(recordEntityPage))
+        .build();
   }
 
   @Override
   public ProfileRecruits profileRecruits(String accountName, Integer page) {
+    MemberEntity member = memberRepository.findByAccountName(accountName)
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+    Page<ParticipantEntity> participantEntityPage =
+        participantRepository.findByMemberAndStatusAndMeetingDateBefore(
+            member,
+            ParticipantStatus.ACCEPTED,
+            LocalDateTime.now(),
+            PageRequest.of(page - 1, NumberConstant.PAGE_SIZE_DEFAULT,
+                Sort.by("meetingDate").descending()));
 
-    return null;
+    List<RecruitEntity> recruitEntityList =
+        participantEntityPage.getContent().stream()
+            .map(ParticipantEntity::getRecruit)
+            .collect(Collectors.toList());
+
+    return ProfileRecruits.builder()
+        .myPageMember(myPageService.getMyPageMember(member))
+        .sportsSkills(myPageService.getSportsSkills(member))
+        .recruitList(new RecruitListDto(participantEntityPage, recruitEntityList))
+        .build();
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/profile/service/impl/ProfileServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/service/impl/ProfileServiceImpl.java
@@ -1,0 +1,29 @@
+package com.anonymous.usports.domain.profile.service.impl;
+
+import com.anonymous.usports.domain.mypage.service.MyPageService;
+import com.anonymous.usports.domain.profile.dto.ProfileRecords;
+import com.anonymous.usports.domain.profile.dto.ProfileRecruits;
+import com.anonymous.usports.domain.profile.service.ProfileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ProfileServiceImpl implements ProfileService {
+
+  private final MyPageService myPageService;
+
+  @Override
+  public ProfileRecords profileRecords(String accountName, Integer page) {
+    
+    return null;
+  }
+
+  @Override
+  public ProfileRecruits profileRecruits(String accountName, Integer page) {
+
+    return null;
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/record/dto/RecordListDto.java
+++ b/src/main/java/com/anonymous/usports/domain/record/dto/RecordListDto.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Page;
 public class RecordListDto {
 
   private int currentPage;
+  private int currentElements;
   private int pageSize;
   private int totalPages;
   private int totalElements;
@@ -27,6 +28,7 @@ public class RecordListDto {
 
   public RecordListDto(Page<RecordEntity> recordEntityPage) {
     this.currentPage = recordEntityPage.getNumber() + 1;
+    this.currentElements = recordEntityPage.getNumberOfElements();
     this.pageSize = recordEntityPage.getSize();
     this.totalPages = recordEntityPage.getTotalPages();
     this.totalElements = (int) recordEntityPage.getTotalElements();

--- a/src/main/java/com/anonymous/usports/domain/record/repository/RecordRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/record/repository/RecordRepository.java
@@ -4,6 +4,8 @@ import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.record.entity.RecordEntity;
 import com.anonymous.usports.domain.sports.entity.SportsEntity;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +19,6 @@ public interface RecordRepository extends JpaRepository<RecordEntity, Long> {
       @Param("sportsList") List<SportsEntity> sportsList);
 
   List<RecordEntity> findAllByMemberIn(List<MemberEntity> member);
+
+  Page<RecordEntity> findByMemberOrderByRegisteredAtDesc(MemberEntity member, Pageable pageable);
 }

--- a/src/main/java/com/anonymous/usports/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/controller/RecruitController.java
@@ -5,17 +5,13 @@ import com.anonymous.usports.domain.recruit.dto.RecruitDeleteResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister;
-import com.anonymous.usports.domain.recruit.dto.RecruitSearchListDto;
+import com.anonymous.usports.domain.recruit.dto.RecruitListDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitUpdate;
-import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.domain.recruit.service.RecruitService;
 import com.anonymous.usports.global.type.Gender;
 import io.swagger.annotations.ApiOperation;
-import javax.persistence.criteria.CriteriaBuilder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.Criteria;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -95,7 +91,7 @@ public class RecruitController {
 
   @ApiOperation("운동 모집글 검색")
   @GetMapping("/recruits")
-  public ResponseEntity<RecruitSearchListDto> getRecruitList(
+  public ResponseEntity<RecruitListDto> getRecruitList(
       @RequestParam(required = false, defaultValue = "1") int page,
       @RequestParam(required = false) String search,
       @RequestParam(required = false) String region,
@@ -104,7 +100,7 @@ public class RecruitController {
       @RequestParam(required = false) boolean closeInclude
       ){
 
-    RecruitSearchListDto result =
+    RecruitListDto result =
         recruitService.getRecruitsByConditions(page, search, region, sports, gender, closeInclude);
 
     return ResponseEntity.ok(result);

--- a/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitListDto.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitListDto.java
@@ -15,7 +15,7 @@ import org.springframework.data.domain.Page;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class RecruitSearchListDto {
+public class RecruitListDto {
 
   private int currentPage;//현재 페이지
   private int currentElements;//현재 페이지 데이터 개수
@@ -25,7 +25,7 @@ public class RecruitSearchListDto {
 
   List<RecruitDto> list;
 
-  public RecruitSearchListDto(Page<RecruitEntity> page) {
+  public RecruitListDto(Page<RecruitEntity> page) {
     this.currentPage = page.getNumber() + 1;
     this.currentElements = page.getNumberOfElements();
     this.pageSize = page.getSize();

--- a/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitListDto.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitListDto.java
@@ -1,5 +1,6 @@
 package com.anonymous.usports.domain.recruit.dto;
 
+import com.anonymous.usports.domain.participant.entity.ParticipantEntity;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,6 +33,15 @@ public class RecruitListDto {
     this.totalElement = (int)page.getTotalElements();
     this.totalPages = page.getTotalPages();
     this.list = page.getContent().stream().map(RecruitDto::fromEntity).collect(Collectors.toList());
+  }
+
+  public RecruitListDto(Page<ParticipantEntity> page, List<RecruitEntity> list) {
+    this.currentPage = page.getNumber() + 1;
+    this.currentElements = page.getNumberOfElements();
+    this.pageSize = page.getSize();
+    this.totalElement = (int)page.getTotalElements();
+    this.totalPages = page.getTotalPages();
+    this.list = list.stream().map(RecruitDto::fromEntity).collect(Collectors.toList());
   }
 
 

--- a/src/main/java/com/anonymous/usports/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/service/RecruitService.java
@@ -4,11 +4,9 @@ package com.anonymous.usports.domain.recruit.service;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister;
 import com.anonymous.usports.domain.recruit.dto.RecruitDto;
-import com.anonymous.usports.domain.recruit.dto.RecruitSearchListDto;
+import com.anonymous.usports.domain.recruit.dto.RecruitListDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitUpdate;
-import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.global.type.Gender;
-import org.springframework.data.domain.Page;
 
 public interface RecruitService {
 
@@ -40,7 +38,7 @@ public interface RecruitService {
   /**
    * 여러 조건에 따른 Recruit 리스트 반환
    */
-  RecruitSearchListDto getRecruitsByConditions(
+  RecruitListDto getRecruitsByConditions(
       int page, String search, String region, String sports, Gender gender, boolean closeInclude);
 
 }

--- a/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
@@ -7,7 +7,7 @@ import com.anonymous.usports.domain.participant.repository.ParticipantRepository
 import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister.Request;
-import com.anonymous.usports.domain.recruit.dto.RecruitSearchListDto;
+import com.anonymous.usports.domain.recruit.dto.RecruitListDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitUpdate;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.domain.recruit.repository.RecruitRepository;
@@ -146,7 +146,7 @@ public class RecruitServiceImpl implements RecruitService {
 
   @Override
   @Transactional
-  public RecruitSearchListDto getRecruitsByConditions(
+  public RecruitListDto getRecruitsByConditions(
       int page, String search, String region, String sports, Gender gender, boolean closeInclude) {
 
     if (!StringUtils.hasText(search)) {
@@ -172,7 +172,7 @@ public class RecruitServiceImpl implements RecruitService {
           search, region, sportsEntity, gender, pageRequest);
     }
 
-    return new RecruitSearchListDto(findPage);
+    return new RecruitListDto(findPage);
   }
 
   private void validateAuthority(MemberEntity member, Long memberId) {

--- a/src/main/java/com/anonymous/usports/global/constant/NumberConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/NumberConstant.java
@@ -5,4 +5,6 @@ public class NumberConstant {
 
   public static final int PAGE_SIZE_DEFAULT = 10;
 
+  public static final int PAGE_SIZE_PROFILE = 20;
+
 }

--- a/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
@@ -14,7 +14,7 @@ import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister.Request;
-import com.anonymous.usports.domain.recruit.dto.RecruitSearchListDto;
+import com.anonymous.usports.domain.recruit.dto.RecruitListDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitUpdate;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.domain.recruit.repository.RecruitRepository;
@@ -50,13 +50,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @Slf4j
@@ -644,7 +638,7 @@ class RecruitServiceTest {
           PageRequest.of(page - 1, NumberConstant.PAGE_SIZE_DEFAULT, Sort.by("registeredAt").descending())))
           .thenReturn(new PageImpl<>(recruitList));
       //when
-      RecruitSearchListDto result =
+      RecruitListDto result =
           recruitService.getRecruitsByConditions(
               page, search, region, footballString, gender, closeInclude);
 

--- a/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
@@ -63,8 +63,7 @@ class RecruitServiceTest {
   private SportsRepository sportsRepository;
   @Mock
   private RecruitRepository recruitRepository;
-  @Mock
-  private ParticipantRepository participantRepository;
+
 
   @InjectMocks
   private RecruitServiceImpl recruitService;
@@ -76,7 +75,7 @@ class RecruitServiceTest {
         .name("name" + id)
         .email("test@test.com")
         .password("password" + id)
-        .phoneNumber("010-1111-2222")
+        .phoneNumber("010-1111-2 222")
         .birthDate(LocalDate.now())
         .gender(Gender.MALE)
         .role(Role.USER)


### PR DESCRIPTION
### 변경사항
Profile 페이지의 Record, Recruit 를 각각 구현했습니다.

두 페이지 모두 
- MyPageMember 데이터
- SportsSkills  

가 필요합니다. 

MyPageService에서 위의 두가지 데이터를 불러오는 부분 메서드를 그대로 사용했습니다.

각 페이지에는 위의 두가지 데이터가 공통으로 포함되고
Record 페이지에는 멤버의 Record가 최신순으로,
Recruit 페이지에는 멤버의 마감된 Recruit가 최신순으로 정렬되어 반환됩니다.

**[테스트]**
API 테스트를 진행했습니다.
테스트코드는 각 List를 불러오는 부분을 제외하고는 MyPageService Test에서 수행했기 때문에 생략했습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 

