### PR TITLE
Refactor/Fix : Response 데이터타입 수정, Recruit 생성 시 문제 수정

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/member/controller/MemberContoller.java
+++ b/src/main/java/com/anonymous/usports/domain/member/controller/MemberContoller.java
@@ -52,6 +52,7 @@ public class MemberContoller {
         notificationService.checkUnreadNotificationAndSetSession(memberDto.getMemberId(), httpServletRequest);
 
         return ResponseEntity.ok(MemberLogin.Response.builder()
+                .member(memberDto)
                         .tokenDto(tokenProvider.saveTokenInRedis(memberDto.getEmail()))
                 .build());
     }

--- a/src/main/java/com/anonymous/usports/domain/member/dto/MemberLogin.java
+++ b/src/main/java/com/anonymous/usports/domain/member/dto/MemberLogin.java
@@ -20,6 +20,7 @@ public class MemberLogin {
     @NoArgsConstructor
     @Builder
     public static class Response {
+        private MemberDto member;
         private TokenDto tokenDto;
     }
 }

--- a/src/main/java/com/anonymous/usports/domain/participant/dto/ParticipantDto.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/dto/ParticipantDto.java
@@ -2,6 +2,7 @@ package com.anonymous.usports.domain.participant.dto;
 
 import com.anonymous.usports.domain.participant.entity.ParticipantEntity;
 import com.anonymous.usports.global.type.ParticipantStatus;
+import com.anonymous.usports.global.type.SportsGrade;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,6 +23,8 @@ public class ParticipantDto {
 
   private Long recruitId;
 
+  private String sportsSkill;
+
   private LocalDateTime registeredAt;
 
   private LocalDateTime confirmedAt; //모집 확인 받은 시간
@@ -37,6 +40,7 @@ public class ParticipantDto {
         .participantId(participant.getParticipantId())
         .memberId(participant.getMember().getMemberId())
         .recruitId(participant.getRecruit().getRecruitId())
+        .sportsSkill(SportsGrade.doubleToGrade(participant.getSportsSkill()).getDescription())
         .registeredAt(participant.getRegisteredAt())
         .confirmedAt(participant.getConfirmedAt())
         .status(participant.getStatus())

--- a/src/main/java/com/anonymous/usports/domain/participant/entity/ParticipantEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/entity/ParticipantEntity.java
@@ -18,7 +18,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -47,6 +46,9 @@ public class ParticipantEntity {
   @JoinColumn(name = "recruit_id", nullable = false)
   private RecruitEntity recruit;
 
+  @Column(name = "sports_skill", nullable = false)
+  private double sportsSkill;
+
   @CreatedDate
   @Column(name = "registered_at", nullable = false)
   private LocalDateTime registeredAt;
@@ -64,6 +66,7 @@ public class ParticipantEntity {
   @Column(name = "meeting_date")
   private LocalDateTime meetingDate;
 
+
   public ParticipantEntity(MemberEntity member, RecruitEntity recruit) {
     this.member = member;
     this.recruit = recruit;
@@ -71,7 +74,7 @@ public class ParticipantEntity {
     this.meetingDate = recruit.getMeetingDate();
   }
 
-  public void setStatus(ParticipantStatus status){
+  public void setStatus(ParticipantStatus status) {
     this.confirmedAt = LocalDateTime.now();
     this.status = status;
   }

--- a/src/main/java/com/anonymous/usports/domain/participant/service/impl/ParticipantServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/participant/service/impl/ParticipantServiceImpl.java
@@ -12,6 +12,8 @@ import com.anonymous.usports.domain.participant.repository.ParticipantRepository
 import com.anonymous.usports.domain.participant.service.ParticipantService;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.domain.recruit.repository.RecruitRepository;
+import com.anonymous.usports.domain.sportsskill.entity.SportsSkillEntity;
+import com.anonymous.usports.domain.sportsskill.repository.SportsSkillRepository;
 import com.anonymous.usports.global.constant.NumberConstant;
 import com.anonymous.usports.global.constant.ResponseConstant;
 import com.anonymous.usports.global.exception.ErrorCode;
@@ -21,7 +23,6 @@ import com.anonymous.usports.global.exception.ParticipantException;
 import com.anonymous.usports.global.exception.RecruitException;
 import com.anonymous.usports.global.type.ParticipantStatus;
 import com.anonymous.usports.global.type.RecruitStatus;
-import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +40,7 @@ public class ParticipantServiceImpl implements ParticipantService {
   private final MemberRepository memberRepository;
   private final RecruitRepository recruitRepository;
   private final ParticipantRepository participantRepository;
+  private final SportsSkillRepository sportsSkillRepository;
 
   @Override
   @Transactional
@@ -80,8 +82,19 @@ public class ParticipantServiceImpl implements ParticipantService {
           ResponseConstant.JOIN_RECRUIT_ALREADY_ACCEPTED);
     }
 
+    ParticipantEntity participant = new ParticipantEntity(memberEntity, recruitEntity);
+    Optional<SportsSkillEntity> optionalSportsSkill =
+        sportsSkillRepository.findByMemberAndSports(memberEntity, recruitEntity.getSports());
+
+    if (optionalSportsSkill.isPresent()) {
+      SportsSkillEntity sportsSkill = optionalSportsSkill.get();
+      participant.setSportsSkill(sportsSkill.getSportsScoreAsDouble());
+    } else {
+      participant.setSportsSkill(0.0);
+    }
+
     //신청 가능 -> 신청
-    participantRepository.save(new ParticipantEntity(memberEntity, recruitEntity));
+    participantRepository.save(participant);
 
     return new ParticipateResponse(recruitId, memberId, ResponseConstant.JOIN_RECRUIT_COMPLETE);
   }

--- a/src/main/java/com/anonymous/usports/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/controller/RecruitController.java
@@ -6,6 +6,7 @@ import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister;
 import com.anonymous.usports.domain.recruit.dto.RecruitListDto;
+import com.anonymous.usports.domain.recruit.dto.RecruitResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitUpdate;
 import com.anonymous.usports.domain.recruit.service.RecruitService;
 import com.anonymous.usports.global.type.Gender;
@@ -49,8 +50,8 @@ public class RecruitController {
 
   @ApiOperation("운동 모집 게시글 한 건 조회하기")
   @GetMapping("/recruit/{recruitId}")
-  public ResponseEntity<RecruitDto> getRecruit(@PathVariable Long recruitId) {
-    RecruitDto result = recruitService.getRecruit(recruitId);
+  public ResponseEntity<RecruitResponse> getRecruit(@PathVariable Long recruitId) {
+    RecruitResponse result = recruitService.getRecruit(recruitId);
     return ResponseEntity.ok(result);
   }
 

--- a/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitRegister.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitRegister.java
@@ -55,6 +55,7 @@ public class RecruitRegister {
           .lnt(request.getLnt())
           .cost(request.getCost())
           .gender(request.getGender())
+          .currentCount(1)
           .recruitCount(request.getRecruitCount())
           .meetingDate(request.getMeetingDate())
           .recruitStatus(RecruitStatus.RECRUITING)

--- a/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitResponse.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/dto/RecruitResponse.java
@@ -1,0 +1,91 @@
+package com.anonymous.usports.domain.recruit.dto;
+
+import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
+import com.anonymous.usports.global.type.SportsGrade;
+import java.time.LocalDateTime;
+
+/**
+ * FE에서 사용하는 값으로 반환하는 RecruitResponse
+ */
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RecruitResponse {
+  private Long recruitId;
+
+  private Long sportsId;
+
+  private Long memberId;
+
+  private String memberAccountName;
+
+  private String title;
+
+  private String content;
+
+  private String placeName;
+
+  private String region;
+
+  private String streetNameAddr; // 도로명 주소
+
+  private String streetNumberAddr; // 지번 주소
+
+  private double lat;
+
+  private double lnt;
+
+  private int cost;
+
+  private String gender;
+
+  private int recruitCount;
+
+  private LocalDateTime meetingDate;
+
+  private String recruitStatus;
+
+  private String gradeFrom;//필요
+
+  private String gradeTo;
+
+  private LocalDateTime registeredAt;
+
+  private LocalDateTime updatedAt;
+
+  private String participantSportsSkillAverage;
+
+  public static RecruitResponse fromEntity(RecruitEntity recruit){
+    return RecruitResponse.builder()
+        .recruitId(recruit.getRecruitId())
+        .sportsId(recruit.getSports().getSportsId())
+        .memberId(recruit.getMember().getMemberId())
+        .memberAccountName(recruit.getMember().getAccountName())
+        .title(recruit.getTitle())
+        .content(recruit.getContent())
+        .placeName(recruit.getPlaceName())
+        .region(recruit.getRegion())
+        .streetNameAddr(recruit.getStreetNameAddr())
+        .streetNumberAddr(recruit.getStreetNumberAddr())
+        .lat(Double.parseDouble(recruit.getLat()))
+        .lnt(Double.parseDouble(recruit.getLnt()))
+        .cost(recruit.getCost())
+        .gender(recruit.getGender().getDescription())
+        .recruitCount(recruit.getRecruitCount())
+        .meetingDate(recruit.getMeetingDate())
+        .recruitStatus(recruit.getRecruitStatus().getDescription())
+        .gradeFrom(SportsGrade.intToGrade(recruit.getGradeFrom()).getDescription())
+        .gradeTo(SportsGrade.intToGrade(recruit.getGradeTo()).getDescription())
+        .registeredAt(recruit.getRegisteredAt())
+        .updatedAt(recruit.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/service/RecruitService.java
@@ -5,6 +5,7 @@ import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister;
 import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitListDto;
+import com.anonymous.usports.domain.recruit.dto.RecruitResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitUpdate;
 import com.anonymous.usports.global.type.Gender;
 
@@ -18,7 +19,7 @@ public interface RecruitService {
   /**
    * Recruit 조회
    */
-  RecruitDto getRecruit(Long recruitId);
+  RecruitResponse getRecruit(Long recruitId);
 
   /**
    * Recruit 수정

--- a/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
@@ -60,6 +60,11 @@ public class RecruitServiceImpl implements RecruitService {
     RecruitEntity saved =
         recruitRepository.save(Request.toEntity(request, memberEntity, sportsEntity));
 
+    //모집 생성할 때, host participant 추가
+    ParticipantEntity participantEntity = new ParticipantEntity(memberEntity, saved);
+    participantEntity.setStatus(ParticipantStatus.ACCEPTED);
+    participantRepository.save(participantEntity);
+
     return RecruitDto.fromEntity(saved);
   }
 

--- a/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/service/impl/RecruitServiceImpl.java
@@ -6,8 +6,9 @@ import com.anonymous.usports.domain.participant.entity.ParticipantEntity;
 import com.anonymous.usports.domain.participant.repository.ParticipantRepository;
 import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
-import com.anonymous.usports.domain.recruit.dto.RecruitRegister.Request;
 import com.anonymous.usports.domain.recruit.dto.RecruitListDto;
+import com.anonymous.usports.domain.recruit.dto.RecruitRegister.Request;
+import com.anonymous.usports.domain.recruit.dto.RecruitResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitUpdate;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.domain.recruit.repository.RecruitRepository;
@@ -24,6 +25,7 @@ import com.anonymous.usports.global.exception.SportsException;
 import com.anonymous.usports.global.type.Gender;
 import com.anonymous.usports.global.type.ParticipantStatus;
 import com.anonymous.usports.global.type.RecruitStatus;
+import com.anonymous.usports.global.type.SportsGrade;
 import io.jsonwebtoken.lang.Strings;
 import java.util.List;
 import java.util.Objects;
@@ -63,11 +65,21 @@ public class RecruitServiceImpl implements RecruitService {
 
   @Override
   @Transactional
-  public RecruitDto getRecruit(Long recruitId) {
-    return RecruitDto.fromEntity(
-        recruitRepository.findById(recruitId)
-            .orElseThrow(() -> new RecruitException(ErrorCode.RECRUIT_NOT_FOUND))
-    );
+  public RecruitResponse getRecruit(Long recruitId) {
+    RecruitEntity recruit = recruitRepository.findById(recruitId)
+        .orElseThrow(() -> new RecruitException(ErrorCode.RECRUIT_NOT_FOUND));
+    RecruitResponse response = RecruitResponse.fromEntity(recruit);
+    List<ParticipantEntity> participants = participantRepository.findAllByRecruitAndStatus(
+        recruit, ParticipantStatus.ACCEPTED);
+
+    double sportSkillTotal = 0.0;
+    for (ParticipantEntity participant : participants) {
+      sportSkillTotal += participant.getSportsSkill();
+    }
+    response.setParticipantSportsSkillAverage(
+        SportsGrade.doubleToGrade(sportSkillTotal / participants.size()).getDescription());
+
+    return response;
   }
 
   @Override
@@ -160,14 +172,15 @@ public class RecruitServiceImpl implements RecruitService {
       sportsEntity = sportsRepository.findBySportsName(sports)
           .orElseThrow(() -> new SportsException(ErrorCode.SPORTS_NOT_FOUND));
     }
-    PageRequest pageRequest = PageRequest.of(page - 1, NumberConstant.PAGE_SIZE_DEFAULT, Sort.by("registeredAt").descending());
+    PageRequest pageRequest = PageRequest.of(page - 1, NumberConstant.PAGE_SIZE_DEFAULT,
+        Sort.by("registeredAt").descending());
 
     Page<RecruitEntity> findPage = Page.empty();
 
-    if(closeInclude){
+    if (closeInclude) {
       findPage = recruitRepository.findAllByConditionIncludeEND(
           search, region, sportsEntity, gender, pageRequest);
-    }else{
+    } else {
       findPage = recruitRepository.findAllByConditionNotIncludeEND(
           search, region, sportsEntity, gender, pageRequest);
     }

--- a/src/main/java/com/anonymous/usports/domain/sportsskill/entity/SportsSkillEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/sportsskill/entity/SportsSkillEntity.java
@@ -57,6 +57,10 @@ public class SportsSkillEntity {
     this.evaluateCount += 1;
   }
 
+  public double getSportsScoreAsDouble(){
+    return (double) this.sportsScore / this.evaluateCount;
+  }
+
   @Override
   public boolean equals(Object object) {
     if (this == object) {

--- a/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
+++ b/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode {
 
   //Sports 관련
   SPORTS_NOT_FOUND(HttpStatus.NOT_FOUND, "운동 종목을 찾을 수 없습니다."),
+  SPORTS_GRADE_INVALID(HttpStatus.NOT_FOUND, "Sports Grade 값이 잘못되었습니다."),
+
 
   //Recruit 관련
   RECRUIT_NOT_FOUND(HttpStatus.NOT_FOUND, "운동 모집 게시글을 찾을 수 없습니다."),

--- a/src/main/java/com/anonymous/usports/global/type/Gender.java
+++ b/src/main/java/com/anonymous/usports/global/type/Gender.java
@@ -3,11 +3,18 @@ package com.anonymous.usports.global.type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
+@AllArgsConstructor
 public enum Gender {
 
-    MALE, FEMALE, BOTH;
+    MALE("남성"),
+    FEMALE("여성"),
+    BOTH("성별 무관");
 
+    private final String description;
     @JsonCreator
     public static Gender parsing(String inputValue) {
         return Stream.of(Gender.values())

--- a/src/main/java/com/anonymous/usports/global/type/RecruitStatus.java
+++ b/src/main/java/com/anonymous/usports/global/type/RecruitStatus.java
@@ -1,6 +1,15 @@
 package com.anonymous.usports.global.type;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum RecruitStatus {
 
-  RECRUITING, ALMOST_END, END, FINISHED;
+  RECRUITING("모집중"),
+  ALMOST_END("마감 임박"),
+  END("마감");
+
+  private final String description;
 }

--- a/src/main/java/com/anonymous/usports/global/type/SportsGrade.java
+++ b/src/main/java/com/anonymous/usports/global/type/SportsGrade.java
@@ -1,5 +1,7 @@
 package com.anonymous.usports.global.type;
 
+import com.anonymous.usports.global.exception.ErrorCode;
+import com.anonymous.usports.global.exception.SportsException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -8,49 +10,77 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 @Getter
 public enum SportsGrade {
-  ROOKIE(1, "Rookie", "루키"),
-  BEGINNER_1(2, "Beginner 1", "비기너 1"),
-  BEGINNER_2(3, "Beginner 2", "비기너 2"),
-  BEGINNER_3(4, "Beginner 3", "비기너 3"),
-  AMATEUR_1(5, "Amateur 1", "아마추어 1"),
-  AMATEUR_2(6, "Amateur 2", "아마추어 2"),
-  AMATEUR_3(7, "Amateur 3", "아마추어 3"),
-  SEMI_PRO_1(8, "Semi-pro 1", "세미프로 1"),
-  SEMI_PRO_2(9, "Semi-pro 2", "세미프로 2"),
-  PRO(10, "Professional", "프로");
+  ROOKIE(1, "루키"),
+  BEGINNER_1(2, "비기너 1"),
+  BEGINNER_2(3, "비기너 2"),
+  BEGINNER_3(4, "비기너 3"),
+  AMATEUR_1(5, "아마추어 1"),
+  AMATEUR_2(6, "아마추어 2"),
+  AMATEUR_3(7, "아마추어 3"),
+  SEMI_PRO_1(8, "세미프로 1"),
+  SEMI_PRO_2(9, "세미프로 2"),
+  PRO(10, "프로");
 
   private final int score;
-  private final String en;
-  private final String kr;
+  private final String description;
 
-  public static SportsGrade doubleToGrade(double score){
+  public static SportsGrade doubleToGrade(double score) {
 
-    if(score >= 0 && score <= 1){
+    if (score >= 0 && score <= 1) {
       return ROOKIE;
-    }else if(score > 1 && score <= 2){
+    } else if (score > 1 && score <= 2) {
       return BEGINNER_1;
-    }else if(score > 2 && score <= 3){
+    } else if (score > 2 && score <= 3) {
       return BEGINNER_2;
-    }else if(score > 3 && score <= 4){
+    } else if (score > 3 && score <= 4) {
       return BEGINNER_3;
-    }else if(score > 4 && score <= 5){
+    } else if (score > 4 && score <= 5) {
       return AMATEUR_1;
-    }else if(score > 5 && score <= 6){
+    } else if (score > 5 && score <= 6) {
       return AMATEUR_2;
-    }else if(score > 6 && score <= 7){
+    } else if (score > 6 && score <= 7) {
       return AMATEUR_3;
-    }else if(score > 7 && score <= 8){
+    } else if (score > 7 && score <= 8) {
       return SEMI_PRO_1;
-    }else if(score > 8 && score <= 9){
+    } else if (score > 8 && score <= 9) {
       return SEMI_PRO_2;
-    }else if(score > 9 && score <= 10){
+    } else if (score > 9 && score <= 10) {
       return PRO;
     }
 
-    if(score > 10){
+    if (score > 10) {
       log.error("SportsGrade over 10!!!");
       return PRO;
     }
     return ROOKIE;
+  }
+
+  public static SportsGrade intToGrade(int score) {
+    switch (score) {
+      case 1:
+        return ROOKIE;
+      case 2:
+        return BEGINNER_1;
+      case 3:
+        return BEGINNER_2;
+      case 4:
+        return BEGINNER_3;
+      case 5:
+        return AMATEUR_1;
+      case 6:
+        return AMATEUR_2;
+      case 7:
+        return AMATEUR_3;
+      case 8:
+        return SEMI_PRO_1;
+      case 9:
+        return SEMI_PRO_2;
+      case 10:
+        return PRO;
+      default:
+        break;
+    }
+    log.error("Sports Grade Invalid");
+    throw new SportsException(ErrorCode.SPORTS_GRADE_INVALID);
   }
 }

--- a/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.domain.participant.entity.ParticipantEntity;
 import com.anonymous.usports.domain.participant.repository.ParticipantRepository;
 import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
@@ -29,6 +30,7 @@ import com.anonymous.usports.global.exception.MyException;
 import com.anonymous.usports.global.exception.RecruitException;
 import com.anonymous.usports.global.exception.SportsException;
 import com.anonymous.usports.global.type.Gender;
+import com.anonymous.usports.global.type.ParticipantStatus;
 import com.anonymous.usports.global.type.RecruitStatus;
 import com.anonymous.usports.global.type.Role;
 
@@ -63,6 +65,8 @@ class RecruitServiceTest {
   private SportsRepository sportsRepository;
   @Mock
   private RecruitRepository recruitRepository;
+  @Mock
+  private ParticipantRepository participantRepository;
 
 
   @InjectMocks
@@ -448,11 +452,14 @@ class RecruitServiceTest {
       RecruitEntity recruit = createRecruit(10L, member, sports);
       recruit.setRecruitStatus(RecruitStatus.RECRUITING);
 
+
       //given
       when(recruitRepository.findById(10L))
           .thenReturn(Optional.of(recruit));
       when(memberRepository.findById(1L))
           .thenReturn(Optional.of(member));
+      when(participantRepository.findAllByRecruitAndStatus(recruit, ParticipantStatus.ING))
+          .thenReturn(new ArrayList<>());
 
       //when
       RecruitEndResponse response = recruitService.endRecruit(recruit.getRecruitId(),

--- a/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
@@ -3,6 +3,7 @@ package com.anonymous.usports.domain.recruit.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.when;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -145,6 +146,9 @@ class RecruitServiceTest {
       MemberEntity member = createMember(1L);
       RecruitEntity recruit = createRecruit(10L, member, sports);
 
+      ParticipantEntity participantEntity = new ParticipantEntity(member, recruit);
+      participantEntity.setStatus(ParticipantStatus.ACCEPTED);
+
       //given
       RecruitRegister.Request request = createRegisterRequest(recruit);
       when(memberRepository.findById(1L))
@@ -159,6 +163,7 @@ class RecruitServiceTest {
       RecruitDto result = recruitService.registerRecruit(request, member.getMemberId());
 
       //then
+      verify(participantRepository, times(1)).save(participantEntity);
       assertThat(result.getSportsId()).isEqualTo(sports.getSportsId());
       assertThat(result.getMemberId()).isEqualTo(member.getMemberId());
       assertThat(result.getRecruitStatus()).isEqualTo(RecruitStatus.RECRUITING);

--- a/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/recruit/service/RecruitServiceTest.java
@@ -16,6 +16,7 @@ import com.anonymous.usports.domain.recruit.dto.RecruitEndResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister;
 import com.anonymous.usports.domain.recruit.dto.RecruitRegister.Request;
 import com.anonymous.usports.domain.recruit.dto.RecruitListDto;
+import com.anonymous.usports.domain.recruit.dto.RecruitResponse;
 import com.anonymous.usports.domain.recruit.dto.RecruitUpdate;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.domain.recruit.repository.RecruitRepository;
@@ -227,7 +228,7 @@ class RecruitServiceTest {
           .thenReturn(Optional.of(recruit));
 
       //when
-      RecruitDto result = recruitService.getRecruit(10L);
+      RecruitResponse result = recruitService.getRecruit(10L);
 
       //then
       assertThat(result.getRecruitId()).isEqualTo(recruit.getRecruitId());


### PR DESCRIPTION
### 변경사항
**[테스트 코드 수정]**
- 이전에 테스트코드 수정 안한 부분만 수정했습니다.

**[Recruit GET DTO 변경]**
- SportsGrade와 같은 데이터들 반환할 때 description에 있는 String으로 반환해달라는 요청을 받고 수정했습니다.
- 클라이언트에 Response를 보낼 때 ENUM을 사용자에게 보여주기 위한 String으로 수정해서 보내야합니다.
- 몇가지 ENUM 클래스에 description 을 추가하고, 이를 변환하는 메서드를 만들어두었습니다.

**[Recruit 생성 시 host를 참여자로 추가]**
- Recruit 생성시에 host(모집글 등록 자)를 첫번째 Participant로 추가하도록 수정했습니다.

**[Participant 생성 시 SportsSkill 정보 추가]**
- ParticipantEntity에 sportsSkill 필드와 DB에 컬럼을 추가하였습니다.
- 참여 신청 시 사용자의 운동 능력 정보를 볼 수 있게 하기 위함입니다.
- 추가로 SportsSkill 기록이 없는 경우 0.0으로 설정하여, 사용자에게 ROOKIE 상태로 반환되게 됩니다.

**[로그인 시 Member 정보추가]**
- 로그인 시 TokenDto만 반환하던 것에서 MemberDto 정보도 추가로 반환하도록 수정


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

