### PR TITLE
Feat/websocket

### DIFF
--- a/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
+++ b/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
@@ -72,6 +72,7 @@ public enum ErrorCode {
   NOT_RECRUIT_HOST(HttpStatus.BAD_REQUEST, "운동 모임 작성자만 채팅방을 만들 수 있습니다"),
   MEMBER_ALREADY_IN_CHAT_ROOM(HttpStatus.BAD_REQUEST, "이미 유저가 채팅방에 있습니다"),
   USER_NOT_IN_THE_CHAT(HttpStatus.NOT_FOUND, "해당 유저는 채팅에 없습니다"),
+  CANNOT_CREATE_CHAT_WITH_SAME_USER(HttpStatus.BAD_REQUEST, "내 자신과는 chat을 만들 수 없습니다"),
 
   //기타
   ADDRESS_API_ERROR(HttpStatus.BAD_REQUEST, "도로명 주소 입력값이 잘못되었습니다."),

--- a/src/main/java/com/anonymous/usports/websocket/config/WebSocketConfig.java
+++ b/src/main/java/com/anonymous/usports/websocket/config/WebSocketConfig.java
@@ -13,7 +13,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry
-                .addEndpoint("/ws")  // URL 또는 URI
+                .addEndpoint("/ws/chat")  // URL 또는 URI
                 .setAllowedOriginPatterns("*")
                 .withSockJS(); // 소켓을 지원하지 않는 브라우저라면, sockJS를 사용
     }

--- a/src/main/java/com/anonymous/usports/websocket/controller/ChatController.java
+++ b/src/main/java/com/anonymous/usports/websocket/controller/ChatController.java
@@ -1,14 +1,21 @@
 package com.anonymous.usports.websocket.controller;
 
 import com.anonymous.usports.websocket.dto.ChatMessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
-import org.springframework.stereotype.Controller;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
+@RequiredArgsConstructor
+@Slf4j
 public class ChatController {
+
+    private final SimpMessageSendingOperations template;
 
     /**
      * 메세지를 보낼 때
@@ -16,25 +23,30 @@ public class ChatController {
      * /topic/public 을 통해서 채팅에 구독되어 있는 모든 사람들이 메세지를 접근할 수 있다
      * @PayLoad : payload라서 SendTo()에 적힌 곳으로 메세지 넘어간다
      */
-    @MessageMapping("/chat/message")
-    @SendTo("/sub/public")
-    public ChatMessageDto sendMessage(
-            @Payload ChatMessageDto chatMessageDto
+    @MessageMapping("/chat/sendMessage")
+    public void sendMessage(
+            @Payload ChatMessageDto chat
     ) {
-         return chatMessageDto;
+         log.info("Chat {}", chat);
+         chat.setContent(chat.getContent());
+         template.convertAndSend("/sub/chat/room/" + chat.getChatRoomId(), chat);
     }
 
     /**
      * 유저와 웹 소켓이 연결될 때에 생성되는 메세지다
      */
-    @MessageMapping("/chat/add-user")
-    @SendTo("/sub/public")
-    public ChatMessageDto addUser(
-        @Payload ChatMessageDto chatMessageDto,
+    @MessageMapping("/chat/enter")
+    public void addUser(
+        @Payload ChatMessageDto chat,
+        @DestinationVariable Long chatRoomId,
+//        @AuthenticationPrincipal MemberDto memberDto,
         SimpMessageHeaderAccessor headerAccessor
     ) {
-        // Add username in WebSocket session
-        headerAccessor.getSessionAttributes().put("username", chatMessageDto.getSender());
-        return chatMessageDto;
+//        headerAccessor.getSessionAttributes().put("userName", memberDto.getAccountName());
+        headerAccessor.getSessionAttributes().put("chatRoomId", chatRoomId);
+
+        chat.setContent(chat.getSender() + "님이 입장하셨습니다");
+        template.convertAndSend("/sub/chat/room/" + chat.getChatRoomId(), chat);
+
     }
 }

--- a/src/main/java/com/anonymous/usports/websocket/controller/ChatController.java
+++ b/src/main/java/com/anonymous/usports/websocket/controller/ChatController.java
@@ -3,10 +3,7 @@ package com.anonymous.usports.websocket.controller;
 import com.anonymous.usports.websocket.dto.ChatMessageDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,17 +16,18 @@ public class ChatController {
 
     /**
      * 메세지를 보낼 때
+     *
      * @SendTo() : which topic or queue you want to send the message (Message Broker)
      * /topic/public 을 통해서 채팅에 구독되어 있는 모든 사람들이 메세지를 접근할 수 있다
      * @PayLoad : payload라서 SendTo()에 적힌 곳으로 메세지 넘어간다
      */
     @MessageMapping("/chat/sendMessage")
     public void sendMessage(
-            @Payload ChatMessageDto chat
+            ChatMessageDto chat
     ) {
-         log.info("Chat {}", chat);
-         chat.setContent(chat.getContent());
-         template.convertAndSend("/sub/chat/room/" + chat.getChatRoomId(), chat);
+        log.info("Chat {}", chat);
+        chat.setContent(chat.getContent());
+        template.convertAndSend("/sub/chat/room/" + chat.getChatRoomId(), chat);
     }
 
     /**
@@ -37,16 +35,10 @@ public class ChatController {
      */
     @MessageMapping("/chat/enter")
     public void addUser(
-        @Payload ChatMessageDto chat,
-        @DestinationVariable Long chatRoomId,
-//        @AuthenticationPrincipal MemberDto memberDto,
-        SimpMessageHeaderAccessor headerAccessor
+            ChatMessageDto chat
     ) {
-//        headerAccessor.getSessionAttributes().put("userName", memberDto.getAccountName());
-        headerAccessor.getSessionAttributes().put("chatRoomId", chatRoomId);
-
+        log.info("{} 입장", chat.getSender());
         chat.setContent(chat.getSender() + "님이 입장하셨습니다");
         template.convertAndSend("/sub/chat/room/" + chat.getChatRoomId(), chat);
-
     }
 }

--- a/src/main/java/com/anonymous/usports/websocket/controller/ChatRoomController.java
+++ b/src/main/java/com/anonymous/usports/websocket/controller/ChatRoomController.java
@@ -7,6 +7,7 @@ import com.anonymous.usports.websocket.dto.httpbody.CreateDMDto;
 import com.anonymous.usports.websocket.dto.httpbody.CreateRecruitChat;
 import com.anonymous.usports.websocket.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,6 +16,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/chat")
 @RequiredArgsConstructor
+@Slf4j
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
@@ -24,15 +26,14 @@ public class ChatRoomController {
         @PathVariable Long chatRoomId,
         @AuthenticationPrincipal MemberDto memberDto
     ) {
-        return null;
+        return chatRoomService.enterChatRoom(chatRoomId, memberDto);
     }
-
 
     @GetMapping("/list")
     public List<ChatPartakeDto>  getChatRoomList(
             @AuthenticationPrincipal MemberDto memberDto
     ){
-        return null;
+        return chatRoomService.getChatRoomList(memberDto);
     }
 
     @PostMapping("/direct-message")

--- a/src/main/java/com/anonymous/usports/websocket/controller/ChatRoomController.java
+++ b/src/main/java/com/anonymous/usports/websocket/controller/ChatRoomController.java
@@ -21,13 +21,13 @@ public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
 
-    @GetMapping("/{chatRoomId}")
-    public String enterChatRoom(
-        @PathVariable Long chatRoomId,
-        @AuthenticationPrincipal MemberDto memberDto
-    ) {
-        return chatRoomService.enterChatRoom(chatRoomId, memberDto);
-    }
+//    @GetMapping("/{chatRoomId}")
+//    public String enterChatRoom(
+//        @PathVariable Long chatRoomId,
+//        @AuthenticationPrincipal MemberDto memberDto
+//    ) {
+//        return chatRoomService.enterChatRoom(chatRoomId, memberDto);
+//    }
 
     @GetMapping("/list")
     public List<ChatPartakeDto>  getChatRoomList(

--- a/src/main/java/com/anonymous/usports/websocket/controller/htmlcontroller/ChatHtmlController.java
+++ b/src/main/java/com/anonymous/usports/websocket/controller/htmlcontroller/ChatHtmlController.java
@@ -1,0 +1,39 @@
+package com.anonymous.usports.websocket.controller.htmlcontroller;
+
+import com.anonymous.usports.domain.member.dto.MemberDto;
+import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.websocket.service.ChatRoomService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping(value = "/chat")
+@Slf4j
+public class ChatHtmlController {
+
+    private final ChatRoomService chatRoomService;
+    private final MemberRepository memberRepository;
+
+    // todo : 나중에는 로그인한 유저의 데이터를 가지고 와야 한다
+    @GetMapping("/rooms")
+    public ModelAndView getChatRoomList(){
+
+        log.info("All Chat Rooms");
+
+        MemberDto memberDto = MemberDto.fromEntity(memberRepository.findById(4L)
+                .orElseThrow(() -> new RuntimeException("no member")));
+
+        ModelAndView mv = new ModelAndView("chat/rooms");
+
+        mv.addObject("list", chatRoomService.getChatRoomList(memberDto));
+
+        return mv;
+    }
+
+
+}

--- a/src/main/java/com/anonymous/usports/websocket/controller/htmlcontroller/ChatHtmlController.java
+++ b/src/main/java/com/anonymous/usports/websocket/controller/htmlcontroller/ChatHtmlController.java
@@ -6,6 +6,7 @@ import com.anonymous.usports.websocket.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
@@ -35,5 +36,19 @@ public class ChatHtmlController {
         return mv;
     }
 
+    //채팅방 조회
+    @GetMapping("/room")
+    public void getRoom(Long roomId, Model model){
 
+        log.info("# get Chat Room, roomID : " + roomId);
+        log.info("{}", roomId.getClass());
+
+        Long[] memberNum = new Long[]{4L, 5L, 6L, 7L, 8L, 9L};
+        log.info("{}", memberNum);
+
+        MemberDto memberDto = MemberDto.fromEntity(memberRepository.findById(memberNum[(int) Math.round(Math.random() * (memberNum.length - 1))])
+                .orElseThrow(() -> new RuntimeException("no member")));
+
+        model.addAttribute("room", chatRoomService.enterChatRoom(roomId, memberDto));
+    }
 }

--- a/src/main/java/com/anonymous/usports/websocket/dto/ChatEnterDto.java
+++ b/src/main/java/com/anonymous/usports/websocket/dto/ChatEnterDto.java
@@ -1,0 +1,16 @@
+package com.anonymous.usports.websocket.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChatEnterDto {
+
+    private Long chatRoomId;
+    private String chatRoomName;
+    private String username;
+
+}

--- a/src/main/java/com/anonymous/usports/websocket/dto/ChatPartakeDto.java
+++ b/src/main/java/com/anonymous/usports/websocket/dto/ChatPartakeDto.java
@@ -11,14 +11,14 @@ import lombok.*;
 public class ChatPartakeDto {
     private Long partakeId;
     private Long chatRoomId;
-    private Long memberId;
+    private String chatRoomName;
     private Long recruitId;
 
     public static ChatPartakeDto fromEntity(ChatPartakeEntity chatPartake) {
         return ChatPartakeDto.builder()
                 .partakeId(chatPartake.getPartakeId())
                 .chatRoomId(chatPartake.getChatRoomEntity().getChatRoomId())
-                .memberId(chatPartake.getMemberEntity().getMemberId())
+                .chatRoomName(chatPartake.getChatRoomEntity().getChatRoomName())
                 .recruitId(chatPartake.getRecruitId())
                 .build();
     }

--- a/src/main/java/com/anonymous/usports/websocket/repository/ChatPartakeRepository.java
+++ b/src/main/java/com/anonymous/usports/websocket/repository/ChatPartakeRepository.java
@@ -4,8 +4,6 @@ import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.websocket.entity.ChatPartakeEntity;
 import com.anonymous.usports.websocket.entity.ChatRoomEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,13 +12,7 @@ import java.util.Optional;
 @Repository
 public interface ChatPartakeRepository extends JpaRepository<ChatPartakeEntity, Long> {
 
-//    @Query("SELECT c FROM chat_partake c" +
-//            "WHERE c.member_one = :memberOne " +
-//            "and :memberTwo = chat_partake .memberEntity")
-//    Optional<ChatRoomEntity> findChatRoomEntityByMember(
-//            @Param("memberOne") MemberEntity memberOne,
-//            @Param("memberTwo") MemberEntity memberTwo
-//    );
+    List<ChatPartakeEntity> findAllByMemberEntityInAndRecruitIdIsNull(List<MemberEntity> member);
 
     Optional<ChatPartakeEntity> findByChatRoomEntityAndMemberEntity(ChatRoomEntity chatRoom, MemberEntity member);
 

--- a/src/main/java/com/anonymous/usports/websocket/service/ChatRoomService.java
+++ b/src/main/java/com/anonymous/usports/websocket/service/ChatRoomService.java
@@ -1,6 +1,7 @@
 package com.anonymous.usports.websocket.service;
 
 import com.anonymous.usports.domain.member.dto.MemberDto;
+import com.anonymous.usports.websocket.dto.ChatEnterDto;
 import com.anonymous.usports.websocket.dto.ChatPartakeDto;
 import com.anonymous.usports.websocket.dto.httpbody.ChatInviteDto;
 import com.anonymous.usports.websocket.dto.httpbody.CreateDMDto;
@@ -10,7 +11,7 @@ import java.util.List;
 
 public interface ChatRoomService {
 
-    String enterChatRoom(Long chatRoomId, MemberDto memberDto);
+    ChatEnterDto enterChatRoom(Long chatRoomId, MemberDto memberDto);
 
     List<ChatPartakeDto> getChatRoomList(MemberDto memberDto);
 

--- a/src/main/java/com/anonymous/usports/websocket/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/websocket/service/impl/ChatRoomServiceImpl.java
@@ -13,6 +13,7 @@ import com.anonymous.usports.global.exception.ErrorCode;
 import com.anonymous.usports.global.exception.MemberException;
 import com.anonymous.usports.global.exception.RecruitException;
 import com.anonymous.usports.global.type.ParticipantStatus;
+import com.anonymous.usports.websocket.dto.ChatEnterDto;
 import com.anonymous.usports.websocket.dto.ChatPartakeDto;
 import com.anonymous.usports.websocket.dto.httpbody.ChatInviteDto;
 import com.anonymous.usports.websocket.dto.httpbody.CreateDMDto;
@@ -41,7 +42,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
 
     @Override
-    public String enterChatRoom(Long chatRoomId, MemberDto memberDto) {
+    public ChatEnterDto enterChatRoom(Long chatRoomId, MemberDto memberDto) {
+
+
         ChatRoomEntity chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new ChatException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
@@ -52,7 +55,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
             throw new ChatException(ErrorCode.USER_NOT_IN_THE_CHAT);
         }
 
-        return ChatConstant.ENTERED_CHAT_ROOM;
+        return new ChatEnterDto(chatRoomId, chatRoom.getChatRoomName(), member.getAccountName());
     }
 
     private List<ChatPartakeDto> findChatRoomListByDto(MemberDto memberDto) {

--- a/src/main/resources/templates/chat/room.html
+++ b/src/main/resources/templates/chat/room.html
@@ -2,6 +2,8 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 
 <head>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
@@ -13,7 +15,7 @@
 
   <div class="container">
     <div class="col-6">
-      <h1>[[${room.name}]]</h1>
+      <h1>[[${room.chatRoomName}]]</h1>
     </div>
     <div>
       <div id="msgArea" class="col"></div>
@@ -33,9 +35,10 @@
 <script th:inline="javascript">
   $(document).ready(function(){
 
-    var roomName = [[${room.name}]];
-    var roomId = [[${room.roomId}]];
-    var username = "이제준";
+    var roomName = [[${room.chatRoomName}]];
+    var roomId = [[${room.chatRoomId}]];
+    var username = [[${room.username}]];
+    var timeNow = new Date();
 
     console.log(roomName + ", " + roomId + ", " + username);
 
@@ -51,8 +54,8 @@
       stomp.subscribe("/sub/chat/room/" + roomId, function (chat) {
         var content = JSON.parse(chat.body);
 
-        var writer = content.writer;
-        var message = content.message;
+        var writer = content.sender;
+        var message = content.content;
         var str = '';
 
         if(writer === username){
@@ -61,21 +64,26 @@
           str += "<b>" + writer + " : " + message + "</b>";
           str += "</div></div>";
           $("#msgArea").append(str);
+        }  else{
+          str = "<div class='col-6'>";
+          str += "<div class='alert alert-warning'>";
+          str += "<b>" + writer + " : " + message + "</b>";
+          str += "</div></div>";
+          $("#msgArea").append(str);
         }
-
 
         $("#msgArea").append(str);
       });
 
       //3. send(path, header, message)로 메세지를 보낼 수 있음
-      stomp.send('/pub/chat/enter', {}, JSON.stringify({roomId: roomId, writer: username}))
+      stomp.send('/pub/chat/enter', {}, JSON.stringify({chatRoomId: roomId, sender: username, time: timeNow}))
     });
 
     $("#button-send").on("click", function(e){
       var msg = document.getElementById("msg");
 
       console.log(username + ":" + msg.value);
-      stomp.send('/pub/chat/message', {}, JSON.stringify({roomId: roomId, message: msg.value, writer: username}));
+      stomp.send('/pub/chat/sendMessage', {}, JSON.stringify({chatRoomId: roomId, content: msg.value, sender: username}));
       msg.value = '';
     });
   });

--- a/src/main/resources/templates/chat/room.html
+++ b/src/main/resources/templates/chat/room.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+
+<head>
+  <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+  <script src="https://code.jquery.com/jquery-latest.min.js"></script>
+</head>
+
+<body>
+<th:block th:fragment="content">
+
+  <div class="container">
+    <div class="col-6">
+      <h1>[[${room.name}]]</h1>
+    </div>
+    <div>
+      <div id="msgArea" class="col"></div>
+      <div class="col-6">
+        <div class="input-group mb-3">
+          <input type="text" id="msg" class="form-control">
+          <div class="input-group-append">
+            <button class="btn btn-outline-secondary" type="button" id="button-send">전송</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-6"></div>
+  </div>
+</th:block>
+
+<script th:inline="javascript">
+  $(document).ready(function(){
+
+    var roomName = [[${room.name}]];
+    var roomId = [[${room.roomId}]];
+    var username = "이제준";
+
+    console.log(roomName + ", " + roomId + ", " + username);
+
+    var sockJs = new SockJS("/ws/chat");
+    //1. SockJS를 내부에 들고있는 stomp를 내어줌
+    var stomp = Stomp.over(sockJs);
+
+    //2. connection이 맺어지면 실행
+    stomp.connect({}, function (){
+      console.log("STOMP Connection")
+
+      //4. subscribe(path, callback)으로 메세지를 받을 수 있음
+      stomp.subscribe("/sub/chat/room/" + roomId, function (chat) {
+        var content = JSON.parse(chat.body);
+
+        var writer = content.writer;
+        var message = content.message;
+        var str = '';
+
+        if(writer === username){
+          str = "<div class='col-6'>";
+          str += "<div class='alert alert-secondary'>";
+          str += "<b>" + writer + " : " + message + "</b>";
+          str += "</div></div>";
+          $("#msgArea").append(str);
+        }
+
+
+        $("#msgArea").append(str);
+      });
+
+      //3. send(path, header, message)로 메세지를 보낼 수 있음
+      stomp.send('/pub/chat/enter', {}, JSON.stringify({roomId: roomId, writer: username}))
+    });
+
+    $("#button-send").on("click", function(e){
+      var msg = document.getElementById("msg");
+
+      console.log(username + ":" + msg.value);
+      stomp.send('/pub/chat/message', {}, JSON.stringify({roomId: roomId, message: msg.value, writer: username}));
+      msg.value = '';
+    });
+  });
+</script>
+</body>
+</html>
+

--- a/src/main/resources/templates/chat/rooms.html
+++ b/src/main/resources/templates/chat/rooms.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 
+<head>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+</head>
+
 <body>
 <th:block th:fragment="content">
   <p>채팅방 이름</p>

--- a/src/main/resources/templates/chat/rooms.html
+++ b/src/main/resources/templates/chat/rooms.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+
+<body>
+<th:block th:fragment="content">
+  <p>채팅방 이름</p>
+  <div class="container">
+    <div>
+      <ul th:each="room : ${list}">
+        <li><a th:href="@{/chat/room(roomId=${room.chatRoomId})}">[[${room.chatRoomName}]]</a></li>
+      </ul>
+    </div>
+  </div>
+</th:block>
+
+</body>
+
+</html>
+


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->

**_[간단한 테스트]_**
rooms.html과 room.html을 만들어서 websocket 과 STOMP 테스트 진행.
로그인한 사람이 들어간 채팅방 목록을 가지고 오고, 채팅방에 들어가서 실시간 대화하기 테스트 완료.
따로 ChatHtmlController를 만들어서, API 테스트 진행.

STOMP를 통해 채팅방에 subscribe(구독)을 한다.
해당 채팅방에서 채팅을 보내면 publish를 통해서 메세지를 보내게 된다. (여기서 publish를 할 때에, 채팅방의 ID, 메세지 내용, 메세지 보낸 사람의 이름을 같이 발행자에게 보낸다)
채팅방 ID를 통해, 현재 같은 채널에 또는 채팅방에 있는 사람들에게 publish한 채팅 내용을 broadcasting한다.
- broadcasting은 한 사람에게만 전달하는 것이 아닌, 해당 채널에 연결되어 있는 모든 사람에게 메세지를 보내는 것이다.

**_[1대1 채팅방 만들기 API 테스트]_**
- 이미 상대방과 만든 채팅방이 있으면, 다시 만들면 안 됨
- 내 자신과는 1대1 채팅방을 만들 수 없다
- 채팅방을 새로 만들 때에, 채팅방Entity를 만들어주고, chat_partake 엔티티도 만들어줘야 한다

_**[내가 들어간 채팅방 모두 보여주기]**_
- 로그인한 사람의 ID를 가지고, 로그인한 사람이 들어가 있는 모든 채팅방은 리스트로 보여준다

_**[추가로 해야 할 것]**_
운동 모집 그룹 채팅방 생성 테스트
- 이미 그룹 채팅방이 있으면 생성이 되면 안 된다
운동 모집 그룹 채팅방에 초대 테스트
- 이미 초대가 되어 있으면 중복으로 초대가 되면 안 된다
- 운동 모집 그룹에 승인이 안 된 사람은 초대가 되면 안 된다
채팅방 나가기
- 채팅방에 아무도 없게 되면 채팅방은 알아서 삭제가 된다


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 

