### PR TITLE
Refactor: rabbitMQ 플러그인 설치 관련 docker-compose 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - MONGO_INITDB_ROOT_PASSWORD=rootpass
     networks:
       - backend
+    restart: always
   rabbitmq:
     image: rabbitmq:3-management-alpine
     container_name: rabbitmq-stream
@@ -46,6 +47,9 @@ services:
       RABBITMQ_ERLANG_COOKIE: "RabbitMQ-My-Cookies"
       RABBITMQ_DEFAULT_USER: "rootuser"
       RABBITMQ_DEFAULT_PASS: "rootpass"
+    restart: always
+    command: >
+      sh -c 'rabbitmq-plugins enable --offline rabbitmq_stomp rabbitmq_web_stomp && rabbitmq-server'
 
 volumes:
   data: { }

--- a/src/main/resources/templates/chat/room.html
+++ b/src/main/resources/templates/chat/room.html
@@ -39,6 +39,7 @@
     var roomId = [[${room.chatRoomId}]];
     var username = [[${room.username}]];
     var timeNow = new Date();
+    var firstEnter = true;
     let stomp = Stomp.over(new SockJS("/ws/chat"));
     stomp.heartbeat.outgoing = 10000;
     stomp.heartbeat.incoming = 10000;
@@ -47,7 +48,10 @@
       stomp.connect({}, function () {
         console.log("STOMP Connection");
         subscribeToRoom();
-        sendEnterMessage();
+        if(firstEnter == true) {
+          sendEnterMessage();
+          firstEnter = false;
+        }
       }, function (error) {
         console.log('Connection lost! Reconnection...')
         reconnect();


### PR DESCRIPTION
### 변경사항

**AS-IS**

- docker compose 파일 수정해서 docker에 rabbitMQ 설치 시 필요한 플러그인들이 같이 설치되도록 변경했습니다.
- 기존에는 reconnect 시 sendEnterMessage가 계속 작동하여 sendEnterMessage의 위치를 변경했습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 

