### PR TITLE
Refactor : Login시에 회원의 interestSportsList 추가로 반환하도록 수정

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/member/controller/MemberContoller.java
+++ b/src/main/java/com/anonymous/usports/domain/member/controller/MemberContoller.java
@@ -12,10 +12,11 @@ import com.anonymous.usports.domain.member.dto.TokenDto;
 import com.anonymous.usports.domain.member.security.TokenProvider;
 import com.anonymous.usports.domain.member.service.CookieService;
 import com.anonymous.usports.domain.member.service.MemberService;
+import com.anonymous.usports.domain.mypage.service.MyPageService;
 import com.anonymous.usports.domain.notification.service.NotificationService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import javax.servlet.http.Cookie;
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -42,6 +43,7 @@ public class MemberContoller {
   private final TokenProvider tokenProvider;
   private final NotificationService notificationService;
   private final CookieService cookieService;
+  private final MyPageService myPageService;
 
   /**
    * 회원 가입 http://localhost:8080/member/register
@@ -73,9 +75,13 @@ public class MemberContoller {
     TokenDto tokenDto = tokenProvider.saveTokenInRedis(memberDto.getEmail());
     cookieService.setCookieForLogin(httpServletResponse, tokenDto.getAccessToken());
 
+    List<String> interestSportsList =
+        myPageService.getInterestSportsList(memberDto.getMemberId());
+
     return ResponseEntity.ok(MemberLogin.Response.builder()
         .member(memberDto)
         .tokenDto(tokenDto)
+        .interestSportsList(interestSportsList)
         .build());
   }
 

--- a/src/main/java/com/anonymous/usports/domain/member/dto/MemberLogin.java
+++ b/src/main/java/com/anonymous/usports/domain/member/dto/MemberLogin.java
@@ -1,5 +1,6 @@
 package com.anonymous.usports.domain.member.dto;
 
+import java.util.List;
 import lombok.*;
 
 public class MemberLogin {
@@ -22,5 +23,6 @@ public class MemberLogin {
     public static class Response {
         private TokenDto tokenDto;
         private MemberDto member;
+        private List<String> interestSportsList;
     }
 }

--- a/src/main/java/com/anonymous/usports/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/controller/MyPageController.java
@@ -38,7 +38,7 @@ public class MyPageController {
       @AuthenticationPrincipal MemberDto loginMember) {
 
     MemberProfile memberProfile = MemberProfile.builder()
-        .memberInfo(myPageService.getMyPageMember(loginMember.getMemberId()))
+        .memberInfo(myPageService.getMemberInfo(loginMember.getMemberId()))
         .sportsSkills(myPageService.getSportsSkills(loginMember.getMemberId()))
         .build();
 

--- a/src/main/java/com/anonymous/usports/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/service/MyPageService.java
@@ -12,7 +12,9 @@ public interface MyPageService {
 
   MyPageMainDto getMyPageMainData(Long memberId);
 
-  MemberInfo getMyPageMember(Long memberId);
+  MemberInfo getMemberInfo(Long memberId);
+
+  List<String> getInterestSportsList(Long memberId);
 
   List<SportsSkillDto> getSportsSkills(Long memberId);
 

--- a/src/main/java/com/anonymous/usports/domain/profile/service/impl/ProfileServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/service/impl/ProfileServiceImpl.java
@@ -42,7 +42,7 @@ public class ProfileServiceImpl implements ProfileService {
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
 
     return MemberProfile.builder()
-        .memberInfo(myPageService.getMyPageMember(member.getMemberId()))
+        .memberInfo(myPageService.getMemberInfo(member.getMemberId()))
         .sportsSkills(myPageService.getSportsSkills(member.getMemberId()))
         .build();
   }

--- a/src/test/java/com/anonymous/usports/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/mypage/service/MyPageServiceTest.java
@@ -10,9 +10,7 @@ import com.anonymous.usports.domain.member.repository.MemberRepository;
 import com.anonymous.usports.domain.mypage.dto.MemberInfo;
 import com.anonymous.usports.domain.mypage.service.impl.MyPageServiceImpl;
 import com.anonymous.usports.domain.participant.entity.ParticipantEntity;
-import com.anonymous.usports.domain.participant.repository.ParticipantRepository;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
-import com.anonymous.usports.domain.recruit.repository.RecruitRepository;
 import com.anonymous.usports.domain.sports.entity.SportsEntity;
 import com.anonymous.usports.domain.sportsskill.dto.SportsSkillDto;
 import com.anonymous.usports.domain.sportsskill.entity.SportsSkillEntity;
@@ -133,7 +131,7 @@ class MyPageServiceTest {
           .thenReturn(interestedSportsEntityList);
 
       //when
-      MemberInfo memberInfo = myPageService.getMyPageMember(member.getMemberId());
+      MemberInfo memberInfo = myPageService.getMemberInfo(member.getMemberId());
 
       //then
       assertThat(memberInfo.getInterestSportsList().size()).isEqualTo(3);
@@ -156,7 +154,7 @@ class MyPageServiceTest {
           .thenReturn(interestedSportsEntityList);
 
       //when
-      MemberInfo memberInfo = myPageService.getMyPageMember(member.getMemberId());
+      MemberInfo memberInfo = myPageService.getMemberInfo(member.getMemberId());
 
       //then
       assertThat(memberInfo.getInterestSportsList().size()).isEqualTo(3);
@@ -179,7 +177,7 @@ class MyPageServiceTest {
           .thenReturn(interestedSportsEntityList);
 
       //when
-      MemberInfo memberInfo = myPageService.getMyPageMember(member.getMemberId());
+      MemberInfo memberInfo = myPageService.getMemberInfo(member.getMemberId());
 
       //then
       assertThat(memberInfo.getInterestSportsList().size()).isEqualTo(1);
@@ -199,7 +197,7 @@ class MyPageServiceTest {
           .thenReturn(interestedSportsEntityList);
 
       //when
-      MemberInfo memberInfo = myPageService.getMyPageMember(member.getMemberId());
+      MemberInfo memberInfo = myPageService.getMemberInfo(member.getMemberId());
 
       //then
       assertThat(memberInfo.getInterestSportsList().get(0)).isEqualTo("none");


### PR DESCRIPTION
### 변경사항
Login 시에 로그인 회원의 InterestSportsList를 추가로 반환하도록 수정

**[MyPageService.getMyPageMember 수정]**
- getMyPageMember에서 InterestSportsList를 불러오던 부분을 메서드 분리하여 Member 로그인시 사용할 수 있도록 수정
- getMyPageMember에서 랜덤한 3개의 Sports를 뽑아내던 로직 수정 
    - 기존은 중복으로 뽑힐 여지가 있었다고 생각
    - Collections.shuffle() 메서드 이용한 뒤, 맨 앞의 3개 반환

**[회원 로그인 시 interestSportsList 추가 반환]** 
- 위에서 분리한 메서드 `getInterestSportsList(Long memberId)`를 호출하여 응답에 추가함

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

