### PR TITLE
Feature/refactor sports List format 수정

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/member/controller/MemberController.java
+++ b/src/main/java/com/anonymous/usports/domain/member/controller/MemberController.java
@@ -14,6 +14,7 @@ import com.anonymous.usports.domain.member.service.CookieService;
 import com.anonymous.usports.domain.member.service.MemberService;
 import com.anonymous.usports.domain.mypage.service.MyPageService;
 import com.anonymous.usports.domain.notification.service.NotificationService;
+import com.anonymous.usports.domain.sports.dto.SportsDto;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
@@ -37,7 +38,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/member")
 @RequiredArgsConstructor
-public class MemberContoller {
+public class MemberController {
 
   private final MemberService memberService;
   private final TokenProvider tokenProvider;
@@ -75,13 +76,13 @@ public class MemberContoller {
     TokenDto tokenDto = tokenProvider.saveTokenInRedis(memberDto.getEmail());
     cookieService.setCookieForLogin(httpServletResponse, tokenDto.getAccessToken());
 
-    List<String> interestSportsList =
-        myPageService.getInterestSportsList(memberDto.getMemberId());
+    List<SportsDto> interestedSportsList = myPageService.getInterestedSportsList(
+        memberDto.getMemberId());
 
     return ResponseEntity.ok(MemberLogin.Response.builder()
         .member(memberDto)
         .tokenDto(tokenDto)
-        .interestSportsList(interestSportsList)
+        .interestedSportsList(interestedSportsList)
         .build());
   }
 

--- a/src/main/java/com/anonymous/usports/domain/member/dto/MemberLogin.java
+++ b/src/main/java/com/anonymous/usports/domain/member/dto/MemberLogin.java
@@ -1,5 +1,6 @@
 package com.anonymous.usports.domain.member.dto;
 
+import com.anonymous.usports.domain.sports.dto.SportsDto;
 import java.util.List;
 import lombok.*;
 
@@ -23,6 +24,6 @@ public class MemberLogin {
     public static class Response {
         private TokenDto tokenDto;
         private MemberDto member;
-        private List<String> interestSportsList;
+        private List<SportsDto> interestedSportsList;
     }
 }

--- a/src/main/java/com/anonymous/usports/domain/member/dto/MemberUpdate.java
+++ b/src/main/java/com/anonymous/usports/domain/member/dto/MemberUpdate.java
@@ -1,6 +1,7 @@
 package com.anonymous.usports.domain.member.dto;
 
 import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.sports.dto.SportsDto;
 import com.anonymous.usports.global.type.Gender;
 import com.anonymous.usports.global.type.Role;
 import lombok.*;
@@ -47,8 +48,8 @@ public class MemberUpdate {
         @NotBlank(message="자주 활동하는 '시'를 꼭 입력해주세요")
         private String activeRegion;
 
-        private List<Long> interestedSports;
-    }
+        private List<Long> interestedSportsList;
+  }
 
     @Getter
     @Setter
@@ -66,7 +67,8 @@ public class MemberUpdate {
         private String profileImage;
         private String activeRegion;
         private Role role;
-        private List<String> interestedSports;
+
+        private List<SportsDto> interestedSportsList;
 
         public static MemberUpdate.Response fromEntity(MemberEntity memberEntity) {
             return MemberUpdate.Response.builder()

--- a/src/main/java/com/anonymous/usports/domain/mypage/dto/MemberInfo.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/dto/MemberInfo.java
@@ -1,6 +1,7 @@
 package com.anonymous.usports.domain.mypage.dto;
 
 import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.sports.dto.SportsDto;
 import java.util.List;
 
 import lombok.AllArgsConstructor;
@@ -24,21 +25,19 @@ public class MemberInfo {
   private String accountName;
   private String email;
 
-  private List<String> interestSportsList;
-  private int plusAlpha;
-
   private Double mannerScore;
 
+  private List<SportsDto> interestSportsList;
 
-  public MemberInfo(MemberEntity memberEntity, List<String> interestSportsList, int plusAlpha){
+
+  public MemberInfo(MemberEntity memberEntity, List<SportsDto> interestSportsList){
     this.profileImage = memberEntity.getProfileImage();
     this.memberId = memberEntity.getMemberId();
     this.name = memberEntity.getName();
     this.accountName = memberEntity.getAccountName();
     this.email = memberEntity.getEmail();
-    this.interestSportsList = interestSportsList;
-    this.plusAlpha = plusAlpha;
     this.mannerScore = memberEntity.getMannerScore();
+    this.interestSportsList = interestSportsList;
   }
 
 }

--- a/src/main/java/com/anonymous/usports/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/service/MyPageService.java
@@ -5,6 +5,7 @@ import com.anonymous.usports.domain.mypage.dto.MemberInfo;
 import com.anonymous.usports.domain.mypage.dto.MyPageParticipant;
 import com.anonymous.usports.domain.mypage.dto.MyPageRecruit;
 import com.anonymous.usports.domain.mypage.dto.RecruitAndParticipants;
+import com.anonymous.usports.domain.sports.dto.SportsDto;
 import com.anonymous.usports.domain.sportsskill.dto.SportsSkillDto;
 import java.util.List;
 
@@ -14,7 +15,7 @@ public interface MyPageService {
 
   MemberInfo getMemberInfo(Long memberId);
 
-  List<String> getInterestSportsList(Long memberId);
+  List<SportsDto> getInterestedSportsList(Long memberId);
 
   List<SportsSkillDto> getSportsSkills(Long memberId);
 

--- a/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/service/impl/MyPageServiceImpl.java
@@ -16,7 +16,7 @@ import com.anonymous.usports.domain.participant.repository.ParticipantRepository
 import com.anonymous.usports.domain.recruit.dto.RecruitDto;
 import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.domain.recruit.repository.RecruitRepository;
-import com.anonymous.usports.domain.sports.entity.SportsEntity;
+import com.anonymous.usports.domain.sports.dto.SportsDto;
 import com.anonymous.usports.domain.sportsskill.dto.SportsSkillDto;
 import com.anonymous.usports.domain.sportsskill.repository.SportsSkillRepository;
 import com.anonymous.usports.global.exception.ErrorCode;
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Random;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -77,40 +76,24 @@ public class MyPageServiceImpl implements MyPageService {
     MemberEntity member = memberRepository.findById(memberId)
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
 
-    List<InterestedSportsEntity> interestedSportsEntityList =
-        interestedSportsRepository.findAllByMemberEntity(member);
-    int listSize = interestedSportsEntityList.size();
+    List<SportsDto> interestedSportsList = this.getInterestedSportsList(memberId);
 
-    List<String> interestSportsList = this.getInterestSportsList(memberId);
+    Collections.shuffle(interestedSportsList);
 
-    if (listSize <= 3) {
-      return new MemberInfo(member, interestSportsList, 0);
-    }
-
-    Collections.shuffle(interestSportsList);
-    return new MemberInfo(member, interestSportsList.subList(0, 3), listSize - 3);
+    return new MemberInfo(member, interestedSportsList);
   }
 
   @Override
-  public List<String> getInterestSportsList(Long memberId) {
+  public List<SportsDto> getInterestedSportsList(Long memberId) {
     MemberEntity member = memberRepository.findById(memberId)
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
 
     List<InterestedSportsEntity> interestedSportsEntityList =
         interestedSportsRepository.findAllByMemberEntity(member);
 
-    int listSize = interestedSportsEntityList.size();
-
-    List<String> interestSportsList = new ArrayList<>();
-
-    if (listSize == 0) {
-      interestSportsList.add("none");
-      return interestSportsList;
-    }
-
     return interestedSportsEntityList.stream()
         .map(InterestedSportsEntity::getSports)
-        .map(SportsEntity::getSportsName)
+        .map(SportsDto::new)
         .collect(Collectors.toList());
   }
 

--- a/src/test/java/com/anonymous/usports/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/anonymous/usports/domain/member/controller/MemberControllerTest.java
@@ -2,13 +2,17 @@ package com.anonymous.usports.domain.member.controller;
 
 import com.anonymous.usports.domain.member.dto.MemberRegister;
 import com.anonymous.usports.domain.member.security.TokenProvider;
+import com.anonymous.usports.domain.member.service.CookieService;
 import com.anonymous.usports.domain.member.service.MemberService;
+import com.anonymous.usports.domain.mypage.service.MyPageService;
+import com.anonymous.usports.domain.notification.service.NotificationService;
 import com.anonymous.usports.global.constant.MailConstant;
 import com.anonymous.usports.global.type.Gender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -27,11 +31,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(MemberContoller.class)
+@WebMvcTest(MemberController.class)
 public class MemberControllerTest {
 
     @MockBean
     private MemberService memberService;
+    @MockBean
+    private NotificationService notificationService;
+    @MockBean
+    private CookieService cookieService;
+    @MockBean
+    private MyPageService myPageService;
 
     @MockBean
     private TokenProvider tokenProvider;

--- a/src/test/java/com/anonymous/usports/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/member/service/MemberServiceTest.java
@@ -20,6 +20,7 @@ import com.anonymous.usports.domain.member.repository.InterestedSportsRepository
 import com.anonymous.usports.domain.member.repository.MemberRepository;
 import com.anonymous.usports.domain.member.service.impl.MailServiceImpl;
 import com.anonymous.usports.domain.member.service.impl.MemberServiceImpl;
+import com.anonymous.usports.domain.sports.dto.SportsDto;
 import com.anonymous.usports.domain.sports.entity.SportsEntity;
 import com.anonymous.usports.domain.sports.repository.SportsRepository;
 import com.anonymous.usports.global.constant.MailConstant;
@@ -40,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -682,7 +684,7 @@ public class MemberServiceTest {
                     .profileImage("picture")
                     .activeRegion(activeRegion)
                     .profileOpen("close")
-                    .interestedSports(sports)
+                    .interestedSportsList(sports)
                     .build();
         }
 
@@ -708,26 +710,24 @@ public class MemberServiceTest {
 
             List<InterestedSportsEntity> interestedSportsEntities = createInterestedSport(member, sportsEntities);
 
-            List<String> interestedSportResult = new ArrayList<>(Arrays.asList(new String[]{"football", "basketball"}));
+            List<SportsDto> interestedSportResult =
+                sportsEntities.stream().map(SportsDto::new).collect(Collectors.toList());
 
             //when
             when(memberRepository.findById(memberDto.getMemberId()))
                     .thenReturn(Optional.of(member));
 
-            for (int i = 0; i < request.getInterestedSports().size(); i++) {
-                when(sportsRepository.findById(request.getInterestedSports().get(i)))
+            for (int i = 0; i < request.getInterestedSportsList().size(); i++) {
+                when(sportsRepository.findById(request.getInterestedSportsList().get(i)))
                         .thenReturn(Optional.of(sportsEntities.get(i)));
             }
 
             when(interestedSportsRepository.saveAll(interestedSportsEntities))
                     .thenReturn(interestedSportsEntities);
 
-            when(interestedSportsRepository.findAllByMemberEntity(member))
-                    .thenReturn(interestedSportsEntities);
-
             MemberUpdate.Response response = memberService.updateMember(request, memberDto, memberId);
 
-            log.info("{} - {}", response.getInterestedSports(), interestedSportResult);
+            log.info("{} - {}", response.getInterestedSportsList(), interestedSportResult);
             log.info("{}", response.getRole());
             //then
             assertThat(response.getAccountName()).isEqualTo(request.getAccountName());
@@ -735,7 +735,7 @@ public class MemberServiceTest {
             assertThat(response.getPhoneNumber()).isEqualTo(request.getPhoneNumber());
             assertThat(response.getBirthDate()).isEqualTo(request.getBirthDate());
             assertThat(response.getActiveRegion()).isEqualTo(request.getActiveRegion());
-            assertThat(response.getInterestedSports()).isEqualTo(interestedSportResult);
+            assertThat(response.getInterestedSportsList().size()).isEqualTo(2);
             assertThat(response.getRole()).isEqualTo(Role.USER);
         }
 
@@ -765,13 +765,13 @@ public class MemberServiceTest {
             when(memberRepository.findById(memberDto.getMemberId()))
                     .thenReturn(Optional.of(member));
 
-            when(sportsRepository.findById(request.getInterestedSports().get(0)))
+            when(sportsRepository.findById(request.getInterestedSportsList().get(0)))
                     .thenReturn(Optional.of(sportsEntities.get(0)));
 
-            when(sportsRepository.findById(request.getInterestedSports().get(1)))
+            when(sportsRepository.findById(request.getInterestedSportsList().get(1)))
                     .thenReturn(Optional.of(sportsEntities.get(1)));
 
-            when(sportsRepository.findById(request.getInterestedSports().get(2)))
+            when(sportsRepository.findById(request.getInterestedSportsList().get(2)))
                     .thenReturn(Optional.empty());
 
 

--- a/src/test/java/com/anonymous/usports/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/mypage/service/MyPageServiceTest.java
@@ -117,7 +117,7 @@ class MyPageServiceTest {
 
     @Test
     @DisplayName("성공 : 관심운동 5개")
-    void getMyPageMember_5() {
+    void getMyPageMember() {
       MemberEntity member = createMember(1L);
       List<InterestedSportsEntity> interestedSportsEntityList = new ArrayList<>();
       for (int i = 0; i < 5; i++) {
@@ -134,75 +134,9 @@ class MyPageServiceTest {
       MemberInfo memberInfo = myPageService.getMemberInfo(member.getMemberId());
 
       //then
-      assertThat(memberInfo.getInterestSportsList().size()).isEqualTo(3);
-      assertThat(memberInfo.getPlusAlpha()).isEqualTo(2);
+      assertThat(memberInfo.getInterestSportsList().size()).isEqualTo(5);
     }
 
-    @Test
-    @DisplayName("성공 : 관심운동 3개")
-    void getMyPageMember_3() {
-      MemberEntity member = createMember(1L);
-      List<InterestedSportsEntity> interestedSportsEntityList = new ArrayList<>();
-      for (int i = 0; i < 3; i++) {
-        interestedSportsEntityList.add(
-            createInterestSports(10L + i, member, createSports(100L + i)));
-      }
-      //given
-      when(memberRepository.findById(1L))
-          .thenReturn(Optional.of(member));
-      when(interestedSportsRepository.findAllByMemberEntity(member))
-          .thenReturn(interestedSportsEntityList);
-
-      //when
-      MemberInfo memberInfo = myPageService.getMemberInfo(member.getMemberId());
-
-      //then
-      assertThat(memberInfo.getInterestSportsList().size()).isEqualTo(3);
-      assertThat(memberInfo.getPlusAlpha()).isEqualTo(0);
-    }
-
-    @Test
-    @DisplayName("성공 : 관심운동 1개")
-    void getMyPageMember() {
-      MemberEntity member = createMember(1L);
-      List<InterestedSportsEntity> interestedSportsEntityList = new ArrayList<>();
-      for (int i = 0; i < 1; i++) {
-        interestedSportsEntityList.add(
-            createInterestSports(10L + i, member, createSports(100L + i)));
-      }
-      //given
-      when(memberRepository.findById(1L))
-          .thenReturn(Optional.of(member));
-      when(interestedSportsRepository.findAllByMemberEntity(member))
-          .thenReturn(interestedSportsEntityList);
-
-      //when
-      MemberInfo memberInfo = myPageService.getMemberInfo(member.getMemberId());
-
-      //then
-      assertThat(memberInfo.getInterestSportsList().size()).isEqualTo(1);
-      assertThat(memberInfo.getPlusAlpha()).isEqualTo(0);
-    }
-
-    @Test
-    @DisplayName("성공 : 관심운동 0개")
-    void getMyPageMember_0() {
-      MemberEntity member = createMember(1L);
-      List<InterestedSportsEntity> interestedSportsEntityList = new ArrayList<>();
-
-      //given
-      when(memberRepository.findById(1L))
-          .thenReturn(Optional.of(member));
-      when(interestedSportsRepository.findAllByMemberEntity(member))
-          .thenReturn(interestedSportsEntityList);
-
-      //when
-      MemberInfo memberInfo = myPageService.getMemberInfo(member.getMemberId());
-
-      //then
-      assertThat(memberInfo.getInterestSportsList().get(0)).isEqualTo("none");
-      assertThat(memberInfo.getPlusAlpha()).isEqualTo(0);
-    }
   }
 
   private SportsSkillEntity createSportsSkill(Long id, MemberEntity member, SportsEntity sports) {


### PR DESCRIPTION
### 변경사항
**[MyPageService.getInterestedSportsList 변경 사항]**
(전)
- 관심 운동 List는 무조건 3개 이하 랜덤으로 뽑아서 주고, 나머지는 plusAlpha라는 데이터로 보냄  
- ex) ListSize = 5일 때 , 3개 랜덤으로 뽑아서 size=3인 List와 plusAlpha=2 반환 

(후)
- 관심 운동 List 개수에 상관없이 전부를 담은 List를 반환
- 랜덤 3개와 plusAlpha 또는 "none"은 FE 단에서 처리하도록 수정

**[회원 로그인, 회원 정보 수정 변경 사항]** (두번째 커밋에 실수로 포함됨)
- 회원 정보 수정 - 관심 운동 종목 LIst 삭제 후 저장 하는 로직 수정
- 반환 값을 List<SportsDto>로 수정
    - 운동 종목 List, 관심 운동 종목 List는 앞으로 모든 응답을 `List<SportsDto>`로 보내기로 결정
    - 운동 종목 List 변수명 : `sportsList`로 고정
    - 관심 운동 종목 List 변수명 : `interestedSportsList`로 고정 (interestSportsList x)  

**[MemberControllerTest 변경 사항]**
- `@MockBean` -> `CookieService`, `MyPageService`, `NotificationService` 추가
- MemberControllerTest 실패하던 것 Fix

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

