### PR TITLE
Feat: 프로필 이미지 등록/변경/삭제

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/member/controller/MemberController.java
+++ b/src/main/java/com/anonymous/usports/domain/member/controller/MemberController.java
@@ -32,7 +32,9 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Api(tags = "회원(Member)")
 @RestController
@@ -147,6 +149,19 @@ public class MemberController {
       @AuthenticationPrincipal MemberDto memberDto
   ) {
     return memberService.updateMember(request, memberDto, id);
+  }
+
+  /**
+   * 프로필 이미지 등록 / 변경 / 삭제 http://localhost:8080/member/{memberId}/profile-image
+   */
+  @PutMapping("/{memberId}/profile-image")
+  @PreAuthorize("hasAnyRole('ROLE_UNAUTH', 'ROLE_ADMIN', 'ROLE_USER')")
+  @ApiOperation(value = "프로필 이미지 변경, 삭제", notes = "회원 정보 수정과 별개로 프로필 이미지만 변경 및 삭제")
+  public MemberUpdate.Response updateMemberProfileImage(
+      @PathVariable("memberId") Long id,
+      @RequestPart(value = "profileImage",required = false) MultipartFile profileImage,
+      @AuthenticationPrincipal MemberDto memberDto){
+    return memberService.updateMemberProfileImage(profileImage, memberDto, id);
   }
 
   /**

--- a/src/main/java/com/anonymous/usports/domain/member/dto/MemberUpdate.java
+++ b/src/main/java/com/anonymous/usports/domain/member/dto/MemberUpdate.java
@@ -43,8 +43,6 @@ public class MemberUpdate {
         @NotBlank(message="공개 비공개 여부를 입력해주세요, open 또는 close을 입력해주세요")
         private String profileOpen;
 
-        private String profileImage;
-
         @NotBlank(message="자주 활동하는 '시'를 꼭 입력해주세요")
         private String activeRegion;
 

--- a/src/main/java/com/anonymous/usports/domain/member/entity/MemberEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/member/entity/MemberEntity.java
@@ -122,9 +122,16 @@ public class MemberEntity {
     this.phoneNumber = request.getPhoneNumber();
     this.birthDate = request.getBirthDate();
     this.gender = request.getGender();
-    this.profileImage = request.getProfileImage();
     this.activeRegion = request.getActiveRegion();
     this.role = Role.USER;
+  }
+
+  public void updateMemberProfileImage(String profileImageAddress) {
+    if (profileImageAddress == null) {
+      this.profileImage = null;
+    } else {
+      this.profileImage = profileImageAddress;
+    }
   }
 
   /**

--- a/src/main/java/com/anonymous/usports/domain/member/service/MemberService.java
+++ b/src/main/java/com/anonymous/usports/domain/member/service/MemberService.java
@@ -2,6 +2,8 @@ package com.anonymous.usports.domain.member.service;
 
 
 import com.anonymous.usports.domain.member.dto.*;
+import com.anonymous.usports.domain.member.dto.MemberUpdate.Response;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
 
@@ -33,6 +35,11 @@ public interface MemberService {
     MemberUpdate.Response updateMember(MemberUpdate.Request request, MemberDto memberDto, Long memberId);
 
     /**
+     * 프로필 이미지 변경 / 삭제
+     */
+    MemberUpdate.Response updateMemberProfileImage(MultipartFile profileImage, MemberDto memberDto, Long memberId);
+
+    /**
      * 회원 비밀번호 수정
      */
     PasswordUpdate.Response updatePassword(PasswordUpdate.Request request, Long id, MemberDto memberDto);
@@ -46,5 +53,6 @@ public interface MemberService {
      * 회원 이메일 인증 번호 재전송
      */
     MailResponse resendEmailAuth(MemberDto memberDto, Long memberId);
+
 
 }

--- a/src/test/java/com/anonymous/usports/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/member/service/MemberServiceTest.java
@@ -681,7 +681,6 @@ public class MemberServiceTest {
                     .phoneNumber(phoneNumber)
                     .birthDate(birthDate)
                     .gender(Gender.FEMALE)
-                    .profileImage("picture")
                     .activeRegion(activeRegion)
                     .profileOpen("close")
                     .interestedSportsList(sports)


### PR DESCRIPTION
# 변경사항

## AS-IS

### [프로필 이미지 등록과 수정, 삭제] 

**상세 설명**
기존 회원 정보 수정과 별도 API로 프로필 이미지만 등록, 수정, 삭제할 수 있도록 구현했습니다.
기존에 이미지가 존재할 경우 기존 이미지의 S3 객체를 제거하고 새로 S3에 업로드 한 후 DB에 새로운 주소 값을 넣도록 했습니다.
삭제하려는 경우 프론트에서 null로 넘겨줄 경우 삭제가 작동하도록 했습니다.

**API테스트**
- 회원의 프로필 이미지가 null일 경우 프로필 이미지를 첨부하여 요청 시 S3업로드와 DB 업데이트 확인
- 회원의 프로필 이미지가 존재할 경우 프로필 이미지를 첨부하여 요청 시 기존 이미지의 S3 객체 삭제 및 새로운 이미지의 S3업로드와 DB 업데이트 확인
- 기존 프로필 이미지가 존재할 경우 첨부 파일 null로 요청될 경우 기존 이미지의 S3 객체 삭제 및 DB에 null로 업데이트 확인


## TO-BE

# 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 