### PR TITLE
customer service

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/customerservice/controller/CsController.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/controller/CsController.java
@@ -1,7 +1,9 @@
 package com.anonymous.usports.domain.customerservice.controller;
 
+import com.anonymous.usports.domain.customerservice.dto.CsDto;
 import com.anonymous.usports.domain.customerservice.dto.DeleteCS;
 import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
+import com.anonymous.usports.domain.customerservice.dto.UpdateCS;
 import com.anonymous.usports.domain.customerservice.service.CsService;
 import com.anonymous.usports.domain.member.dto.MemberDto;
 import io.swagger.annotations.Api;
@@ -11,8 +13,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,9 +43,29 @@ public class CsController {
   @ApiOperation(value = "신고 삭제하기", notes = "해당 글을 쓴 글쓴이가 자신의 신고글을 지울 수 있다. Admin은 모든 신고글을 지울 수 있다")
   @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
   public DeleteCS.Response deleteCS(
-    @PathVariable Long csId,
+    @PathVariable("cs_id") Long csId,
     @AuthenticationPrincipal MemberDto memberDto
   ) {
     return csService.deleteCs(csId, memberDto);
+  }
+
+  @PutMapping("/update/{cs_id}")
+  @ApiOperation(value = "신고 수정하기", notes = "해당 글을 쓴 글쓴이가 자신의 신고글을 지울 수 있다.")
+  @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
+  public UpdateCS.Response updateCs(
+      @PathVariable("cs_id") Long csId,
+      @RequestBody @Valid UpdateCS.Request request,
+      @AuthenticationPrincipal MemberDto memberDto
+  ) {
+    return csService.updateCs(request,csId,memberDto);
+  }
+
+  @GetMapping("/{cs_id}")
+  @ApiOperation(value = "신고글 보기", notes = "신고글의 자세한 내용을 볼 수 있다")
+  @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
+  public CsDto getCsDetail(
+      @PathVariable("cs_id") Long csId
+  ) {
+    return null;
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/customerservice/controller/CsController.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/controller/CsController.java
@@ -1,0 +1,34 @@
+package com.anonymous.usports.domain.customerservice.controller;
+
+import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
+import com.anonymous.usports.domain.customerservice.service.CsService;
+import com.anonymous.usports.domain.member.dto.MemberDto;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api("Customer Service")
+@RestController
+@RequestMapping("/cs")
+@RequiredArgsConstructor
+public class CsController {
+
+  private final CsService csService;
+
+  @PostMapping("/register")
+  @ApiOperation(value = "신고 등록하기", notes = "유저가 신고를 등록할 수 있다")
+  @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
+  public RegisterCS.Response registerCS(
+      @RequestBody @Valid RegisterCS.Request request,
+      @AuthenticationPrincipal MemberDto memberDto
+  ){
+    return csService.registerCs(request, memberDto);
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/customerservice/controller/CsController.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/controller/CsController.java
@@ -1,5 +1,6 @@
 package com.anonymous.usports.domain.customerservice.controller;
 
+import com.anonymous.usports.domain.customerservice.dto.ChangeStatusDto;
 import com.anonymous.usports.domain.customerservice.dto.CsDto;
 import com.anonymous.usports.domain.customerservice.dto.DeleteCS;
 import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
@@ -66,6 +67,21 @@ public class CsController {
   public CsDto getCsDetail(
       @PathVariable("cs_id") Long csId
   ) {
+    return csService.getDetailCs(csId);
+  }
+
+  /**
+   * ========== admin 영역 ===========
+   */
+  @PutMapping("/admin/{cs_id}")
+  @ApiOperation(value = "신고글 상태 바꾸기", notes = "신고글에 대해 진행 상태를 어드민이 바꾸는 것")
+  @PreAuthorize("hasAnyRole('ROLE_ADMIN')")
+  public ChangeStatusDto.Response changeCsStatus(
+      @PathVariable("cs_id") Long csId,
+      @RequestBody ChangeStatusDto.Request request,
+      @AuthenticationPrincipal MemberDto memberDto
+  ) {
     return null;
   }
+
 }

--- a/src/main/java/com/anonymous/usports/domain/customerservice/controller/CsController.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/controller/CsController.java
@@ -2,6 +2,7 @@ package com.anonymous.usports.domain.customerservice.controller;
 
 import com.anonymous.usports.domain.customerservice.dto.ChangeStatusDto;
 import com.anonymous.usports.domain.customerservice.dto.CsDto;
+import com.anonymous.usports.domain.customerservice.dto.CsListDto;
 import com.anonymous.usports.domain.customerservice.dto.DeleteCS;
 import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
 import com.anonymous.usports.domain.customerservice.dto.UpdateCS;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Api("Customer Service")
@@ -70,9 +72,32 @@ public class CsController {
     return csService.getDetailCs(csId);
   }
 
+  @GetMapping("")
+  @ApiOperation(value = "나의 신고글 리스트 보기", notes = "수정한 날짜 기준으로 신고글을 리스트로 가지고 온다")
+  @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
+  public CsListDto getCsList(
+      @AuthenticationPrincipal MemberDto memberDto,
+      @RequestParam(required = false, defaultValue = "1") int page
+  ) {
+    return csService.getCsList(memberDto, page);
+  }
+
   /**
    * ========== admin 영역 ===========
    */
+
+  @GetMapping("/admin")
+  @ApiOperation(value = "신고글 찾기", notes = "Admin이 신고글 찾는 것")
+  @PreAuthorize("hasAnyRole('ROLE_ADMIN')")
+  public CsListDto getCsListAdmin(
+      @RequestParam(required = false, defaultValue = "1") int page,
+      @RequestParam(required = false) String email,
+      @RequestParam(required = false) int statusNum,
+      @AuthenticationPrincipal MemberDto memberDto
+  ) {
+    return csService.getCsListAdmin(memberDto, email, statusNum, page);
+  }
+
   @PutMapping("/admin/{cs_id}")
   @ApiOperation(value = "신고글 상태 바꾸기", notes = "신고글에 대해 진행 상태를 어드민이 바꾸는 것")
   @PreAuthorize("hasAnyRole('ROLE_ADMIN')")
@@ -81,7 +106,6 @@ public class CsController {
       @RequestBody ChangeStatusDto.Request request,
       @AuthenticationPrincipal MemberDto memberDto
   ) {
-    return null;
+    return csService.changeCsStatus(request, csId, memberDto);
   }
-
 }

--- a/src/main/java/com/anonymous/usports/domain/customerservice/controller/CsController.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/controller/CsController.java
@@ -12,8 +12,10 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/cs")
 @RequiredArgsConstructor
+@Slf4j
 public class CsController {
 
   private final CsService csService;
@@ -67,6 +70,7 @@ public class CsController {
   @ApiOperation(value = "신고글 보기", notes = "신고글의 자세한 내용을 볼 수 있다")
   @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
   public CsDto getCsDetail(
+      @AuthenticationPrincipal MemberDto memberDto,
       @PathVariable("cs_id") Long csId
   ) {
     return csService.getDetailCs(csId);
@@ -85,16 +89,24 @@ public class CsController {
   /**
    * ========== admin 영역 ===========
    */
-
   @GetMapping("/admin")
   @ApiOperation(value = "신고글 찾기", notes = "Admin이 신고글 찾는 것")
   @PreAuthorize("hasAnyRole('ROLE_ADMIN')")
   public CsListDto getCsListAdmin(
       @RequestParam(required = false, defaultValue = "1") int page,
       @RequestParam(required = false) String email,
-      @RequestParam(required = false) int statusNum,
+      @RequestParam(required = false) String statusNum,
       @AuthenticationPrincipal MemberDto memberDto
   ) {
+
+    if (!StringUtils.hasText(email)) {
+      email = null;
+    }
+
+    if (!StringUtils.hasText(statusNum)) {
+      statusNum = null;
+    }
+
     return csService.getCsListAdmin(memberDto, email, statusNum, page);
   }
 

--- a/src/main/java/com/anonymous/usports/domain/customerservice/controller/CsController.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/controller/CsController.java
@@ -1,5 +1,6 @@
 package com.anonymous.usports.domain.customerservice.controller;
 
+import com.anonymous.usports.domain.customerservice.dto.DeleteCS;
 import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
 import com.anonymous.usports.domain.customerservice.service.CsService;
 import com.anonymous.usports.domain.member.dto.MemberDto;
@@ -9,6 +10,8 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,5 +33,15 @@ public class CsController {
       @AuthenticationPrincipal MemberDto memberDto
   ){
     return csService.registerCs(request, memberDto);
+  }
+
+  @DeleteMapping("/delete/{cs_id}")
+  @ApiOperation(value = "신고 삭제하기", notes = "해당 글을 쓴 글쓴이가 자신의 신고글을 지울 수 있다. Admin은 모든 신고글을 지울 수 있다")
+  @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
+  public DeleteCS.Response deleteCS(
+    @PathVariable Long csId,
+    @AuthenticationPrincipal MemberDto memberDto
+  ) {
+    return csService.deleteCs(csId, memberDto);
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/customerservice/dto/ChangeStatusDto.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/dto/ChangeStatusDto.java
@@ -1,0 +1,30 @@
+package com.anonymous.usports.domain.customerservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class ChangeStatusDto {
+
+  @Getter
+  @Setter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
+  public static class Request {
+    private int statusNum;
+  }
+
+  @Getter
+  @Setter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
+  public static class Response {
+    private String message;
+    private String csStatus;
+  }
+
+}

--- a/src/main/java/com/anonymous/usports/domain/customerservice/dto/CsDto.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/dto/CsDto.java
@@ -1,0 +1,45 @@
+package com.anonymous.usports.domain.customerservice.dto;
+
+import com.anonymous.usports.domain.customerservice.entity.CsEntity;
+import com.anonymous.usports.domain.member.dto.MemberDto;
+import com.anonymous.usports.global.type.CsStatus;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CsDto {
+
+  private Long csId;
+
+  private MemberDto memberDto;
+
+  private String title;
+
+  private String content;
+
+  private CsStatus csStatus;
+
+  private LocalDateTime registeredAt;
+
+  private LocalDateTime updatedAt;
+
+  public static CsDto fromEntity(CsEntity cs) {
+    return CsDto.builder()
+        .csId(cs.getCsId())
+        .memberDto(MemberDto.fromEntity(cs.getMemberEntity()))
+        .title(cs.getTitle())
+        .content(cs.getContent())
+        .registeredAt(cs.getRegisteredAt())
+        .updatedAt(cs.getUpdatedAt())
+        .build();
+  }
+
+}

--- a/src/main/java/com/anonymous/usports/domain/customerservice/dto/CsListDto.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/dto/CsListDto.java
@@ -1,0 +1,2 @@
+package com.anonymous.usports.domain.customerservice.dto;public class CsListDto {
+}

--- a/src/main/java/com/anonymous/usports/domain/customerservice/dto/CsListDto.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/dto/CsListDto.java
@@ -1,2 +1,22 @@
-package com.anonymous.usports.domain.customerservice.dto;public class CsListDto {
+package com.anonymous.usports.domain.customerservice.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class CsListDto {
+
+  private int pageNum;
+  private int totalPageNum;
+  private int elementsInPage;
+  private int allElementsCount;
+  private List<CsDto> csList;
 }

--- a/src/main/java/com/anonymous/usports/domain/customerservice/dto/DeleteCS.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/dto/DeleteCS.java
@@ -1,0 +1,20 @@
+package com.anonymous.usports.domain.customerservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class DeleteCS {
+
+  @Getter
+  @Setter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
+  public static class Response {
+    private Long csId;
+    private String message;
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/customerservice/dto/RegisterCS.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/dto/RegisterCS.java
@@ -1,0 +1,42 @@
+package com.anonymous.usports.domain.customerservice.dto;
+
+import com.anonymous.usports.domain.customerservice.entity.CsEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class RegisterCS {
+
+  @Getter
+  @Setter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
+  public static class Request{
+    private String title;
+    private String content;
+  }
+
+  @Getter
+  @Setter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
+  public static class Response{
+    private Long csId;
+    private String title;
+    private String content;
+    private String status;
+
+    public static Response fromEntity(CsEntity cs) {
+      return Response.builder()
+          .csId(cs.getCsId())
+          .title(cs.getTitle())
+          .content(cs.getContent())
+          .status(cs.getCsStatus().getDescription())
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/customerservice/dto/UpdateCS.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/dto/UpdateCS.java
@@ -1,6 +1,5 @@
 package com.anonymous.usports.domain.customerservice.dto;
 
-import com.anonymous.usports.domain.customerservice.entity.CsEntity;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,15 +7,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-public class RegisterCS {
+public class UpdateCS {
 
   @Getter
   @Setter
-  @AllArgsConstructor
   @NoArgsConstructor
+  @AllArgsConstructor
   @Builder
   public static class Request{
-
     @NotBlank(message="신고 제목은 필수 입력 사항입니다")
     private String title;
 
@@ -24,24 +22,16 @@ public class RegisterCS {
     private String content;
   }
 
+
   @Getter
   @Setter
-  @AllArgsConstructor
   @NoArgsConstructor
+  @AllArgsConstructor
   @Builder
   public static class Response{
-    private Long csId;
     private String title;
     private String content;
-    private String status;
+    private String message;
 
-    public static Response fromEntity(CsEntity cs) {
-      return Response.builder()
-          .csId(cs.getCsId())
-          .title(cs.getTitle())
-          .content(cs.getContent())
-          .status(cs.getCsStatus().getDescription())
-          .build();
-    }
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/customerservice/entity/CsEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/entity/CsEntity.java
@@ -8,6 +8,8 @@ import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -47,6 +49,7 @@ public class CsEntity {
   private String content;
 
   @Column(name = "status", nullable = false)
+  @Enumerated(value= EnumType.STRING)
   private CsStatus csStatus;
 
   @CreatedDate

--- a/src/main/java/com/anonymous/usports/domain/customerservice/entity/CsEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/entity/CsEntity.java
@@ -1,0 +1,58 @@
+package com.anonymous.usports.domain.customerservice.entity;
+
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.global.type.CsStatus;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "customer_service")
+@EntityListeners(AuditingEntityListener.class)
+public class CsEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long csId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name="member_id", nullable = false)
+  private MemberEntity memberEntity;
+
+  @Column(name = "title", nullable = false)
+  private String title;
+
+  @Column(name = "content", nullable = false)
+  private String content;
+
+  @Column(name = "status", nullable = false)
+  private CsStatus csStatus;
+
+  @CreatedDate
+  @Column(name="registered_at", nullable = false)
+  private LocalDateTime registeredAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/anonymous/usports/domain/customerservice/entity/CsEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/entity/CsEntity.java
@@ -63,6 +63,10 @@ public class CsEntity {
     this.csStatus = csStatus;
   }
 
+  public void updateStatus(CsStatus csStatus){
+    this.csStatus = csStatus;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/src/main/java/com/anonymous/usports/domain/customerservice/entity/CsEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/entity/CsEntity.java
@@ -1,8 +1,10 @@
 package com.anonymous.usports.domain.customerservice.entity;
 
+import com.anonymous.usports.domain.customerservice.dto.UpdateCS;
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.global.type.CsStatus;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
@@ -55,4 +57,26 @@ public class CsEntity {
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
 
+  public void updateCs(UpdateCS.Request request, CsStatus csStatus) {
+    this.title = request.getTitle();
+    this.content = request.getContent();
+    this.csStatus = csStatus;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CsEntity csEntity = (CsEntity) o;
+    return Objects.equals(csId, csEntity.csId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(csId);
+  }
 }

--- a/src/main/java/com/anonymous/usports/domain/customerservice/repository/CsRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/repository/CsRepository.java
@@ -1,0 +1,10 @@
+package com.anonymous.usports.domain.customerservice.repository;
+
+import com.anonymous.usports.domain.customerservice.entity.CsEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CsRepository extends JpaRepository<CsEntity, Long> {
+
+}

--- a/src/main/java/com/anonymous/usports/domain/customerservice/repository/CsRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/repository/CsRepository.java
@@ -17,10 +17,13 @@ public interface CsRepository extends JpaRepository<CsEntity, Long> {
   @Query(value = "SELECT cs FROM customer_service cs"
       + " WHERE (:member IS NULL OR cs.memberEntity = :member)"
       + " AND (:status IS NULL OR cs.csStatus = :status)"
-      + "ORDER BY cs.updatedAt DESC")
-  Page<CsEntity> findALlByConditionsFromAdmin(
+      + " ORDER BY cs.updatedAt DESC")
+  Page<CsEntity> findAllByConditionsFromAdmin(
       @Param("member") MemberEntity member,
       @Param("status") CsStatus csStatus,
       Pageable pageable
   );
+
+  // http://localhost:8080/cs/admin?email=&statusNum=&page=
+  // http://localhost:8080/cs/admin
 }

--- a/src/main/java/com/anonymous/usports/domain/customerservice/repository/CsRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/repository/CsRepository.java
@@ -1,10 +1,26 @@
 package com.anonymous.usports.domain.customerservice.repository;
 
 import com.anonymous.usports.domain.customerservice.entity.CsEntity;
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.global.type.CsStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CsRepository extends JpaRepository<CsEntity, Long> {
+  Page<CsEntity> findAllByMemberEntityOrderByUpdatedAtDesc(MemberEntity member, Pageable pageable);
 
+  @Query(value = "SELECT cs FROM customer_service cs"
+      + " WHERE (:member IS NULL OR cs.memberEntity = :member)"
+      + " AND (:status IS NULL OR cs.csStatus = :status)"
+      + "ORDER BY cs.updatedAt DESC")
+  Page<CsEntity> findALlByConditionsFromAdmin(
+      @Param("member") MemberEntity member,
+      @Param("status") CsStatus csStatus,
+      Pageable pageable
+  );
 }

--- a/src/main/java/com/anonymous/usports/domain/customerservice/service/CsService.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/service/CsService.java
@@ -1,10 +1,13 @@
 package com.anonymous.usports.domain.customerservice.service;
 
+import com.anonymous.usports.domain.customerservice.dto.DeleteCS;
 import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
 import com.anonymous.usports.domain.member.dto.MemberDto;
 
 public interface CsService {
 
   RegisterCS.Response registerCs(RegisterCS.Request request, MemberDto memberDto);
+
+  DeleteCS.Response deleteCs(Long csId, MemberDto memberDto);
 
 }

--- a/src/main/java/com/anonymous/usports/domain/customerservice/service/CsService.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/service/CsService.java
@@ -1,5 +1,7 @@
 package com.anonymous.usports.domain.customerservice.service;
 
+import com.anonymous.usports.domain.customerservice.dto.ChangeStatusDto;
+import com.anonymous.usports.domain.customerservice.dto.CsDto;
 import com.anonymous.usports.domain.customerservice.dto.DeleteCS;
 import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
 import com.anonymous.usports.domain.customerservice.dto.UpdateCS;
@@ -12,5 +14,9 @@ public interface CsService {
   DeleteCS.Response deleteCs(Long csId, MemberDto memberDto);
 
   UpdateCS.Response updateCs(UpdateCS.Request request, Long csId, MemberDto memberDto);
+
+  CsDto getDetailCs(Long csId);
+
+  ChangeStatusDto.Response changeCsStatus(ChangeStatusDto.Request request, Long csId, MemberDto memberDto);
 
 }

--- a/src/main/java/com/anonymous/usports/domain/customerservice/service/CsService.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/service/CsService.java
@@ -1,0 +1,10 @@
+package com.anonymous.usports.domain.customerservice.service;
+
+import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
+import com.anonymous.usports.domain.member.dto.MemberDto;
+
+public interface CsService {
+
+  RegisterCS.Response registerCs(RegisterCS.Request request, MemberDto memberDto);
+
+}

--- a/src/main/java/com/anonymous/usports/domain/customerservice/service/CsService.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/service/CsService.java
@@ -20,7 +20,7 @@ public interface CsService {
 
   CsListDto getCsList(MemberDto member, int page);
 
-  CsListDto getCsListAdmin(MemberDto member, String email, int statusNum, int page);
+  CsListDto getCsListAdmin(MemberDto member, String email, String statusNum, int page);
 
   ChangeStatusDto.Response changeCsStatus(ChangeStatusDto.Request request, Long csId, MemberDto memberDto);
 

--- a/src/main/java/com/anonymous/usports/domain/customerservice/service/CsService.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/service/CsService.java
@@ -2,6 +2,7 @@ package com.anonymous.usports.domain.customerservice.service;
 
 import com.anonymous.usports.domain.customerservice.dto.ChangeStatusDto;
 import com.anonymous.usports.domain.customerservice.dto.CsDto;
+import com.anonymous.usports.domain.customerservice.dto.CsListDto;
 import com.anonymous.usports.domain.customerservice.dto.DeleteCS;
 import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
 import com.anonymous.usports.domain.customerservice.dto.UpdateCS;
@@ -16,6 +17,10 @@ public interface CsService {
   UpdateCS.Response updateCs(UpdateCS.Request request, Long csId, MemberDto memberDto);
 
   CsDto getDetailCs(Long csId);
+
+  CsListDto getCsList(MemberDto member, int page);
+
+  CsListDto getCsListAdmin(MemberDto member, String email, int statusNum, int page);
 
   ChangeStatusDto.Response changeCsStatus(ChangeStatusDto.Request request, Long csId, MemberDto memberDto);
 

--- a/src/main/java/com/anonymous/usports/domain/customerservice/service/CsService.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/service/CsService.java
@@ -2,6 +2,7 @@ package com.anonymous.usports.domain.customerservice.service;
 
 import com.anonymous.usports.domain.customerservice.dto.DeleteCS;
 import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
+import com.anonymous.usports.domain.customerservice.dto.UpdateCS;
 import com.anonymous.usports.domain.member.dto.MemberDto;
 
 public interface CsService {
@@ -9,5 +10,7 @@ public interface CsService {
   RegisterCS.Response registerCs(RegisterCS.Request request, MemberDto memberDto);
 
   DeleteCS.Response deleteCs(Long csId, MemberDto memberDto);
+
+  UpdateCS.Response updateCs(UpdateCS.Request request, Long csId, MemberDto memberDto);
 
 }

--- a/src/main/java/com/anonymous/usports/domain/customerservice/service/impl/CsServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/service/impl/CsServiceImpl.java
@@ -1,0 +1,40 @@
+package com.anonymous.usports.domain.customerservice.service.impl;
+
+import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
+import com.anonymous.usports.domain.customerservice.entity.CsEntity;
+import com.anonymous.usports.domain.customerservice.repository.CsRepository;
+import com.anonymous.usports.domain.customerservice.service.CsService;
+import com.anonymous.usports.domain.member.dto.MemberDto;
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.global.exception.ErrorCode;
+import com.anonymous.usports.global.exception.MemberException;
+import com.anonymous.usports.global.type.CsStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CsServiceImpl implements CsService {
+
+  private final CsRepository csRepository;
+  private final MemberRepository memberRepository;
+
+  @Override
+  public RegisterCS.Response registerCs(RegisterCS.Request request, MemberDto memberDto) {
+
+    MemberEntity member = memberRepository.findById(memberDto.getMemberId())
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+    CsEntity cs = CsEntity.builder()
+        .title(request.getTitle())
+        .content(request.getContent())
+        .memberEntity(member)
+        .csStatus(CsStatus.Registered)
+        .build();
+
+    csRepository.save(cs);
+
+    return RegisterCS.Response.fromEntity(cs);
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/customerservice/service/impl/CsServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/service/impl/CsServiceImpl.java
@@ -2,6 +2,7 @@ package com.anonymous.usports.domain.customerservice.service.impl;
 
 import com.anonymous.usports.domain.customerservice.dto.DeleteCS;
 import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
+import com.anonymous.usports.domain.customerservice.dto.UpdateCS;
 import com.anonymous.usports.domain.customerservice.entity.CsEntity;
 import com.anonymous.usports.domain.customerservice.repository.CsRepository;
 import com.anonymous.usports.domain.customerservice.service.CsService;
@@ -16,6 +17,7 @@ import com.anonymous.usports.global.type.CsStatus;
 import com.anonymous.usports.global.type.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -63,5 +65,22 @@ public class CsServiceImpl implements CsService {
   @Override
   public DeleteCS.Response deleteCs(Long csId, MemberDto memberDto) {
     return deleteCSById(csId, memberDto);
+  }
+
+  @Override
+  @Transactional
+  public UpdateCS.Response updateCs(UpdateCS.Request request, Long csId, MemberDto memberDto) {
+
+    CsEntity cs = csRepository.findById(csId)
+        .orElseThrow(() -> new CsException(ErrorCode.NO_CS_FOUND));
+
+    if (!memberDto.getMemberId().equals(cs.getMemberEntity().getMemberId()))
+      throw new CsException(ErrorCode.CS_NOT_WRITTEN_BY_CURRENT_USER);
+
+    CsStatus curStatus = cs.getCsStatus();
+
+    cs.updateCs(request, curStatus);
+
+    return new UpdateCS.Response(request.getTitle(), request.getContent(), CsConstant.SUCCESSFULLY_UPDATED);
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/customerservice/service/impl/CsServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/customerservice/service/impl/CsServiceImpl.java
@@ -1,5 +1,6 @@
 package com.anonymous.usports.domain.customerservice.service.impl;
 
+import com.anonymous.usports.domain.customerservice.dto.DeleteCS;
 import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
 import com.anonymous.usports.domain.customerservice.entity.CsEntity;
 import com.anonymous.usports.domain.customerservice.repository.CsRepository;
@@ -7,9 +8,12 @@ import com.anonymous.usports.domain.customerservice.service.CsService;
 import com.anonymous.usports.domain.member.dto.MemberDto;
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.global.constant.CsConstant;
+import com.anonymous.usports.global.exception.CsException;
 import com.anonymous.usports.global.exception.ErrorCode;
 import com.anonymous.usports.global.exception.MemberException;
 import com.anonymous.usports.global.type.CsStatus;
+import com.anonymous.usports.global.type.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -36,5 +40,28 @@ public class CsServiceImpl implements CsService {
     csRepository.save(cs);
 
     return RegisterCS.Response.fromEntity(cs);
+  }
+
+  private DeleteCS.Response deleteCSById(Long csId, MemberDto memberDto) {
+    MemberEntity member = memberRepository.findById(memberDto.getMemberId())
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+    CsEntity cs = csRepository.findById(csId)
+        .orElseThrow(() -> new CsException(ErrorCode.NO_CS_FOUND));
+
+    if (Role.ADMIN.equals(member.getRole())) {
+      csRepository.delete(cs);
+    }
+
+    if (member.equals(cs.getMemberEntity())) {
+      csRepository.delete(cs);
+    }
+
+    return new DeleteCS.Response(csId, CsConstant.SUCCESSFULLY_DELETED);
+  }
+
+  @Override
+  public DeleteCS.Response deleteCs(Long csId, MemberDto memberDto) {
+    return deleteCSById(csId, memberDto);
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/member/controller/MemberController.java
+++ b/src/main/java/com/anonymous/usports/domain/member/controller/MemberController.java
@@ -15,7 +15,6 @@ import com.anonymous.usports.domain.member.service.MemberService;
 import com.anonymous.usports.domain.notification.service.NotificationService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -36,7 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/member")
 @RequiredArgsConstructor
-public class MemberContoller {
+public class MemberController {
 
   private final MemberService memberService;
   private final TokenProvider tokenProvider;

--- a/src/main/java/com/anonymous/usports/domain/member/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/anonymous/usports/domain/member/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package com.anonymous.usports.domain.member.security;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+// 인증 실패
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException) throws IOException, ServletException {
+
+    // 유효한 자격증명을 제공하지 않고 접근하려 할 때 401(인증 실패)
+    response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/member/security/SecurityConfig.java
+++ b/src/main/java/com/anonymous/usports/domain/member/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.anonymous.usports.domain.member.security;
 
+import com.anonymous.usports.domain.member.security.handler.CustomAccessDeniedHandler;
 import com.anonymous.usports.domain.member.security.handler.OAuth2SuccessHandler;
 import com.anonymous.usports.domain.member.service.impl.CustomOAuth2MemberService;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,8 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter authenticationFilter;
     private final CustomOAuth2MemberService customOAuth2MemberService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -41,7 +44,10 @@ public class SecurityConfig {
                  .and().successHandler(oAuth2SuccessHandler);
 
          http
-                .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling()
+                  .authenticationEntryPoint(customAuthenticationEntryPoint)
+                  .accessDeniedHandler(customAccessDeniedHandler);
 
         return http.build();
     }

--- a/src/main/java/com/anonymous/usports/domain/member/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/anonymous/usports/domain/member/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,24 @@
+package com.anonymous.usports.domain.member.security.handler;
+
+import com.anonymous.usports.global.exception.ErrorCode;
+import com.anonymous.usports.global.exception.MemberException;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+    // 권한 체크 후 인가 실패 시 동작
+    response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    throw new MemberException(ErrorCode.NO_AUTHORITY_ERROR);
+  }
+}

--- a/src/main/java/com/anonymous/usports/global/constant/CsConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/CsConstant.java
@@ -4,4 +4,6 @@ public class CsConstant {
   public static final String SUCCESSFULLY_DELETED = "신고글이 잘 삭제가 되었습니다";
 
   public static final String SUCCESSFULLY_UPDATED = "신고글 수정이 정상적으로 완료되었습니다";
+
+  public static final String CS_STATUS_SUCCESSFULLY_CHANGED = "신고글에 대한 진행상태가 바뀌었습니다";
 }

--- a/src/main/java/com/anonymous/usports/global/constant/CsConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/CsConstant.java
@@ -2,4 +2,6 @@ package com.anonymous.usports.global.constant;
 
 public class CsConstant {
   public static final String SUCCESSFULLY_DELETED = "신고글이 잘 삭제가 되었습니다";
+
+  public static final String SUCCESSFULLY_UPDATED = "신고글 수정이 정상적으로 완료되었습니다";
 }

--- a/src/main/java/com/anonymous/usports/global/constant/CsConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/CsConstant.java
@@ -1,0 +1,5 @@
+package com.anonymous.usports.global.constant;
+
+public class CsConstant {
+  public static final String SUCCESSFULLY_DELETED = "신고글이 잘 삭제가 되었습니다";
+}

--- a/src/main/java/com/anonymous/usports/global/constant/CsConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/CsConstant.java
@@ -6,4 +6,6 @@ public class CsConstant {
   public static final String SUCCESSFULLY_UPDATED = "신고글 수정이 정상적으로 완료되었습니다";
 
   public static final String CS_STATUS_SUCCESSFULLY_CHANGED = "신고글에 대한 진행상태가 바뀌었습니다";
+
+  public static final int maxElements = 20;
 }

--- a/src/main/java/com/anonymous/usports/global/exception/CsException.java
+++ b/src/main/java/com/anonymous/usports/global/exception/CsException.java
@@ -1,0 +1,23 @@
+package com.anonymous.usports.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class CsException extends RuntimeException{
+    private ErrorCode errorCode;
+    private String errorMessage;
+
+    public CsException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+    }
+
+}

--- a/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
+++ b/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
@@ -79,6 +79,8 @@ public enum ErrorCode {
   //Type
   TYPE_INVALID_ERROR(HttpStatus.BAD_REQUEST, "Type(enum)이 잘못되었습니다."),
 
+  // cs 관련
+  NO_CS_FOUND(HttpStatus.BAD_REQUEST, "신고글이 존재하지 않습니다"),
 
   //기타
   ADDRESS_API_ERROR(HttpStatus.BAD_REQUEST, "도로명 주소 입력값이 잘못되었습니다."),

--- a/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
+++ b/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
@@ -81,6 +81,7 @@ public enum ErrorCode {
 
   // cs 관련
   NO_CS_FOUND(HttpStatus.BAD_REQUEST, "신고글이 존재하지 않습니다"),
+  CS_NOT_WRITTEN_BY_CURRENT_USER(HttpStatus.UNAUTHORIZED, "해당 신고글은, 현재 로그인한 유저가 작성한 글이 아닙니다"),
 
   //기타
   ADDRESS_API_ERROR(HttpStatus.BAD_REQUEST, "도로명 주소 입력값이 잘못되었습니다."),

--- a/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
+++ b/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
@@ -82,6 +82,7 @@ public enum ErrorCode {
   // cs 관련
   NO_CS_FOUND(HttpStatus.BAD_REQUEST, "신고글이 존재하지 않습니다"),
   CS_NOT_WRITTEN_BY_CURRENT_USER(HttpStatus.UNAUTHORIZED, "해당 신고글은, 현재 로그인한 유저가 작성한 글이 아닙니다"),
+  INPUT_VALUE_NOT_EXIST_FOR_CS_STATUS(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다. 1~3을 입력해주세요"),
 
   //기타
   ADDRESS_API_ERROR(HttpStatus.BAD_REQUEST, "도로명 주소 입력값이 잘못되었습니다."),

--- a/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
+++ b/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
@@ -83,6 +83,7 @@ public enum ErrorCode {
   NO_CS_FOUND(HttpStatus.BAD_REQUEST, "신고글이 존재하지 않습니다"),
   CS_NOT_WRITTEN_BY_CURRENT_USER(HttpStatus.UNAUTHORIZED, "해당 신고글은, 현재 로그인한 유저가 작성한 글이 아닙니다"),
   INPUT_VALUE_NOT_EXIST_FOR_CS_STATUS(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다. 1~3을 입력해주세요"),
+  PAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "페이지를 찾을 수 없습니다"),
 
   //기타
   ADDRESS_API_ERROR(HttpStatus.BAD_REQUEST, "도로명 주소 입력값이 잘못되었습니다."),

--- a/src/main/java/com/anonymous/usports/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/anonymous/usports/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.anonymous.usports.global.exception;
 import io.jsonwebtoken.JwtException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -13,6 +14,12 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleException(Exception e) {
     ErrorResponse errorResponse = new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+    return new ResponseEntity<>(errorResponse, errorResponse.getErrorCode().getStatusCode());
+  }
+
+  @ExceptionHandler(AccessDeniedException.class)
+  public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+    ErrorResponse errorResponse = new ErrorResponse(ErrorCode.NO_AUTHORITY_ERROR, e.getMessage());
     return new ResponseEntity<>(errorResponse, errorResponse.getErrorCode().getStatusCode());
   }
 

--- a/src/main/java/com/anonymous/usports/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/anonymous/usports/global/exception/GlobalExceptionHandler.java
@@ -28,6 +28,12 @@ public class GlobalExceptionHandler {
     return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatusCode());
   }
 
+  @ExceptionHandler(CsException.class)
+  public ResponseEntity<ErrorResponse> handleCsException(CsException e) {
+    ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
+    return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatusCode());
+  }
+
   @ExceptionHandler(MemberException.class)
   public ResponseEntity<ErrorResponse> handleMemberException(MemberException e) {
     ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());

--- a/src/main/java/com/anonymous/usports/global/type/CsStatus.java
+++ b/src/main/java/com/anonymous/usports/global/type/CsStatus.java
@@ -7,9 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum CsStatus {
 
-  Registered("문의가 등록이 되었습니다"),
-  ING("문의를 해결하는 중입니다"),
-  Finished("해결이 되었습니다");
+  Registered(1, "문의가 등록이 되었습니다"),
+  ING(2, "문의를 해결하는 중입니다"),
+  Finished(3, "해결이 되었습니다");
 
+  private final int value;
   private final String description;
 }

--- a/src/main/java/com/anonymous/usports/global/type/CsStatus.java
+++ b/src/main/java/com/anonymous/usports/global/type/CsStatus.java
@@ -1,0 +1,15 @@
+package com.anonymous.usports.global.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CsStatus {
+
+  Registered("문의가 등록이 되었습니다"),
+  ING("문의를 해결하는 중입니다"),
+  Finished("해결이 되었습니다");
+
+  private final String description;
+}

--- a/src/main/java/com/anonymous/usports/global/type/CsStatus.java
+++ b/src/main/java/com/anonymous/usports/global/type/CsStatus.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum CsStatus {
 
-  Registered(1, "문의가 등록이 되었습니다"),
+  REGISTERED(1, "문의가 등록이 되었습니다"),
   ING(2, "문의를 해결하는 중입니다"),
-  Finished(3, "해결이 되었습니다");
+  FINISHED(3, "해결이 되었습니다");
 
   private final int value;
   private final String description;

--- a/src/test/java/com/anonymous/usports/domain/customerservice/service/impl/CsServiceImplTest.java
+++ b/src/test/java/com/anonymous/usports/domain/customerservice/service/impl/CsServiceImplTest.java
@@ -1,0 +1,62 @@
+package com.anonymous.usports.domain.customerservice.service.impl;
+
+import com.anonymous.usports.domain.customerservice.entity.CsEntity;
+import com.anonymous.usports.domain.customerservice.repository.CsRepository;
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.global.type.CsStatus;
+import com.anonymous.usports.global.type.Gender;
+import com.anonymous.usports.global.type.Role;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+public class CsServiceImplTest {
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @Mock
+  private CsRepository csRepository;
+
+  @InjectMocks
+  private CsServiceImpl csService;
+
+  private MemberEntity createMember(Long id) {
+    return MemberEntity.builder()
+        .memberId(id)
+        .accountName("accountName" + id)
+        .name("name" + id)
+        .email("test@test.com")
+        .password("password" + id)
+        .phoneNumber("010-1111-2222")
+        .birthDate(LocalDate.now())
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .profileOpen(true)
+        .build();
+  }
+
+  private CsEntity createCS(Long id, MemberEntity member,CsStatus csStatus) {
+    return CsEntity.builder()
+        .csId(id)
+        .memberEntity(member)
+        .title("this is title " + id)
+        .content("this is content " + id)
+        .registeredAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .csStatus(csStatus)
+        .build();
+  }
+
+
+
+
+
+}

--- a/src/test/java/com/anonymous/usports/domain/customerservice/service/impl/CsServiceImplTest.java
+++ b/src/test/java/com/anonymous/usports/domain/customerservice/service/impl/CsServiceImplTest.java
@@ -1,19 +1,33 @@
 package com.anonymous.usports.domain.customerservice.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.anonymous.usports.domain.customerservice.dto.ChangeStatusDto;
+import com.anonymous.usports.domain.customerservice.dto.CsDto;
+import com.anonymous.usports.domain.customerservice.dto.CsListDto;
+import com.anonymous.usports.domain.customerservice.dto.DeleteCS;
 import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
+import com.anonymous.usports.domain.customerservice.dto.UpdateCS;
 import com.anonymous.usports.domain.customerservice.entity.CsEntity;
 import com.anonymous.usports.domain.customerservice.repository.CsRepository;
 import com.anonymous.usports.domain.member.dto.MemberDto;
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.member.repository.MemberRepository;
+import com.anonymous.usports.global.constant.CsConstant;
+import com.anonymous.usports.global.exception.CsException;
+import com.anonymous.usports.global.exception.ErrorCode;
+import com.anonymous.usports.global.exception.MemberException;
 import com.anonymous.usports.global.type.CsStatus;
 import com.anonymous.usports.global.type.Gender;
 import com.anonymous.usports.global.type.Role;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +37,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 @ExtendWith(MockitoExtension.class)
 @Slf4j
@@ -136,6 +152,746 @@ public class CsServiceImplTest {
       assertThat(response.getStatus()).isEqualTo(CsStatus.REGISTERED.getDescription());
     }
 
+    @Test
+    @DisplayName("유저 신고글 등록 실패 - 없는 유저")
+    void failRegisterCsUSER() {
+      //given
+      String title = "제목입니다";
+      String content = "내용입니다";
+
+      RegisterCS.Request request = RegisterCS.Request.builder()
+          .title(title)
+          .content(content)
+          .build();
+
+      MemberEntity member = createMember(1L, Role.USER);
+
+      //when
+      when(memberRepository.findById(1L)).thenReturn(Optional.empty());
+
+      MemberException response = catchThrowableOfType(() ->
+          csService.registerCs(request, MemberDto.fromEntity(member)),
+          MemberException.class);
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+    }
+  }
+
+  @Nested
+  @DisplayName("신고글 삭제")
+  class deleteCS{
+
+    @Test
+    @DisplayName("성공 - 유저 삭제 성공")
+    void deleteSuccessUSER() {
+      //given
+      String title = "this is title";
+      String content = "this is content";
+
+      MemberEntity user = createMember(1L, Role.USER);
+      CsEntity cs = createCS(11L, title, content, user, CsStatus.REGISTERED);
+
+      //when
+      when(memberRepository.findById(user.getMemberId())).thenReturn(Optional.of(user));
+
+      when(csRepository.findById(11L)).thenReturn(Optional.of(cs));
+
+      DeleteCS.Response response = csService.deleteCs(11L, MemberDto.fromEntity(user));
+
+      //then
+      verify(csRepository, times(1)).delete(cs);
+      assertThat(response.getCsId()).isEqualTo(11L);
+      assertThat(response.getMessage()).isEqualTo(CsConstant.SUCCESSFULLY_DELETED);
+    }
+
+    @Test
+    @DisplayName("성공 - 어드민 다른 게시물 삭제")
+    void deleteSuccessADMINOtherCs() {
+      //given
+      String title = "this is title";
+      String content = "this is content";
+
+      MemberEntity admin = createMember(123L, Role.ADMIN);
+
+      MemberEntity user = createMember(1L, Role.USER);
+      CsEntity cs = createCS(11L, title, content, user, CsStatus.REGISTERED);
+
+      //when
+      when(memberRepository.findById(admin.getMemberId())).thenReturn(Optional.of(admin));
+
+      when(csRepository.findById(11L)).thenReturn(Optional.of(cs));
+
+      DeleteCS.Response response = csService.deleteCs(11L, MemberDto.fromEntity(admin));
+
+      //then
+      verify(csRepository, times(1)).delete(cs);
+      assertThat(response.getCsId()).isEqualTo(11L);
+      assertThat(response.getMessage()).isEqualTo(CsConstant.SUCCESSFULLY_DELETED);
+    }
+
+    @Test
+    @DisplayName("성공 - 어드민 자신 게시물 삭제")
+    void deleteSuccessADMIN() {
+      //given
+      String title = "this is title";
+      String content = "this is content";
+
+      MemberEntity admin = createMember(123L, Role.ADMIN);
+
+      CsEntity cs = createCS(11L, title, content, admin, CsStatus.REGISTERED);
+
+      //when
+      when(memberRepository.findById(admin.getMemberId())).thenReturn(Optional.of(admin));
+
+      when(csRepository.findById(11L)).thenReturn(Optional.of(cs));
+
+      DeleteCS.Response response = csService.deleteCs(11L, MemberDto.fromEntity(admin));
+
+      //then
+      verify(csRepository, times(1)).delete(cs);
+      assertThat(response.getCsId()).isEqualTo(11L);
+      assertThat(response.getMessage()).isEqualTo(CsConstant.SUCCESSFULLY_DELETED);
+    }
+
+    @Test
+    @DisplayName("실패 - 유저가 다른 게시물 삭제")
+    void failDeleteUSER() {
+      //given
+      String title = "this is title";
+      String content = "this is content";
+
+      MemberEntity user1 = createMember(1L, Role.USER);
+
+      MemberEntity user2 = createMember(123L, Role.USER);
+
+      CsEntity cs = createCS(11L, title, content, user2, CsStatus.REGISTERED);
+
+      //when
+      when(memberRepository.findById(user1.getMemberId())).thenReturn(Optional.of(user1));
+
+      when(csRepository.findById(11L)).thenReturn(Optional.of(cs));
+
+      CsException response = catchThrowableOfType(() ->
+          csService.deleteCs(11L, MemberDto.fromEntity(user1)), CsException.class);
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.CS_NOT_WRITTEN_BY_CURRENT_USER);
+    }
+
+    @Test
+    @DisplayName("실패 - 게시물을 찾을 수 없음")
+    void failDeleteCsNotFound() {
+      //given
+      String title = "this is title";
+      String content = "this is content";
+
+      MemberEntity user1 = createMember(1L, Role.USER);
+
+      CsEntity cs = createCS(11L, title, content, user1, CsStatus.REGISTERED);
+
+      //when
+      when(memberRepository.findById(user1.getMemberId())).thenReturn(Optional.of(user1));
+
+      when(csRepository.findById(11L)).thenReturn(Optional.empty());
+
+      CsException response = catchThrowableOfType(() ->
+          csService.deleteCs(11L, MemberDto.fromEntity(user1)), CsException.class);
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.NO_CS_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패 - 유저를 찾을 수 없음")
+    void failDeleteUserNotFound() {
+      //given
+
+      MemberEntity user1 = createMember(1L, Role.USER);
+
+      //when
+      when(memberRepository.findById(user1.getMemberId())).thenReturn(Optional.empty());
+
+      MemberException response = catchThrowableOfType(() ->
+          csService.deleteCs(11L, MemberDto.fromEntity(user1)), MemberException.class);
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+    }
+  }
+
+  @Nested
+  @DisplayName("신고글 수정")
+  class updateCS{
+
+    @Test
+    @DisplayName("성공 - 자신의 신고 수정")
+    void successUpdateUSER() {
+      //given
+      String title = "this is title";
+      String content = "this is content";
+
+      MemberEntity user = createMember(1L, Role.USER);
+      CsEntity cs = createCS(11L, title, content, user,CsStatus.REGISTERED);
+      CsEntity updateCs = createCS(11L, title + " change", content + " change", user, CsStatus.REGISTERED);
+
+      //when
+      when(csRepository.findById(11L)).thenReturn(Optional.of(cs));
+
+      UpdateCS.Response response = csService.updateCs(
+          UpdateCS.Request.builder()
+              .title(title + " change")
+              .content(content + " change")
+              .build(), 11L, MemberDto.fromEntity(user));
+
+      //then
+      assertThat(response.getContent()).isEqualTo(updateCs.getContent());
+      assertThat(response.getTitle()).isEqualTo(updateCs.getTitle());
+      assertThat(response.getMessage()).isEqualTo(CsConstant.SUCCESSFULLY_UPDATED);
+    }
+
+    @Test
+    @DisplayName("실패 - 다른 사람 신고 수정 시도")
+    void failUpdateUSERDifCs() {
+      //given
+      String title = "this is title";
+      String content = "this is content";
+
+      MemberEntity user = createMember(1L, Role.USER);
+      MemberEntity user2 = createMember(22L, Role.USER);
+
+      CsEntity cs = createCS(11L, title, content, user2,CsStatus.REGISTERED);
+
+      //when
+      when(csRepository.findById(11L)).thenReturn(Optional.of(cs));
+
+      CsException response = catchThrowableOfType(() ->
+          csService.updateCs(
+          UpdateCS.Request.builder()
+              .title(title + " change")
+              .content(content + " change")
+              .build(), 11L, MemberDto.fromEntity(user)), CsException.class);
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.CS_NOT_WRITTEN_BY_CURRENT_USER);
+    }
+
+    @Test
+    @DisplayName("실패 - 어드민 다른 사람 신고 수정 시도")
+    void failUpdateADMINDifCs() {
+      //given
+      String title = "this is title";
+      String content = "this is content";
+
+      MemberEntity user = createMember(1L, Role.ADMIN);
+      MemberEntity user2 = createMember(22L, Role.USER);
+
+      CsEntity cs = createCS(11L, title, content, user2, CsStatus.REGISTERED);
+
+      //when
+      when(csRepository.findById(11L)).thenReturn(Optional.of(cs));
+
+      CsException response = catchThrowableOfType(() ->
+          csService.updateCs(
+              UpdateCS.Request.builder()
+                  .title(title + " change")
+                  .content(content + " change")
+                  .build(), 11L, MemberDto.fromEntity(user)), CsException.class);
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.CS_NOT_WRITTEN_BY_CURRENT_USER);
+    }
+
+    @Test
+    @DisplayName("실패 - 어드민 다른 사람 신고 수정 시도")
+    void failUpdateCsNotFound() {
+      //given
+      String title = "this is title";
+      String content = "this is content";
+
+      MemberEntity user = createMember(1L, Role.ADMIN);
+
+      //when
+      when(csRepository.findById(11L)).thenReturn(Optional.empty());
+
+      CsException response = catchThrowableOfType(() ->
+          csService.updateCs(
+              UpdateCS.Request.builder()
+                  .title(title + " change")
+                  .content(content + " change")
+                  .build(), 11L, MemberDto.fromEntity(user)), CsException.class);
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.NO_CS_FOUND);
+    }
+  }
+
+  @Nested
+  @DisplayName("신고글 자세히 보기")
+  class getCsDetail {
+
+    @Test
+    @DisplayName("성공 - 유저 신고글 자세히 보기")
+    void successGetCs() {
+      //given
+      String title = "this is title";
+      String content = "this is content";
+      MemberEntity member = createMember(1L, Role.USER);
+
+      CsEntity cs = createCS(11L, title, content, member, CsStatus.REGISTERED);
+
+      //when
+      when(csRepository.findById(11L)).thenReturn(Optional.of(cs));
+
+      CsDto csDto = csService.getDetailCs(11L);
+
+      //then
+      assertThat(csDto.getCsId()).isEqualTo(cs.getCsId());
+      assertThat(csDto.getContent()).isEqualTo(cs.getContent());
+      assertThat(csDto.getTitle()).isEqualTo(cs.getTitle());
+    }
+
+    @Test
+    @DisplayName("성공 - 어드민 신고글 자세히 보기")
+    void successGetCsADMIN() {
+      //given
+      String title = "this is title";
+      String content = "this is content";
+      MemberEntity member = createMember(1L, Role.ADMIN);
+
+      CsEntity cs = createCS(11L, title, content, member, CsStatus.REGISTERED);
+
+      //when
+      when(csRepository.findById(11L)).thenReturn(Optional.of(cs));
+
+      CsDto csDto = csService.getDetailCs(11L);
+
+      //then
+      assertThat(csDto.getCsId()).isEqualTo(cs.getCsId());
+      assertThat(csDto.getContent()).isEqualTo(cs.getContent());
+      assertThat(csDto.getTitle()).isEqualTo(cs.getTitle());
+    }
+
+    @Test
+    @DisplayName("실패 - 신고글 ID가 없음")
+    void failGetCs() {
+      //given
+
+      //when
+      when(csRepository.findById(11L)).thenReturn(Optional.empty());
+
+      CsException response = catchThrowableOfType(()->csService.getDetailCs(11L),
+          CsException.class);
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.NO_CS_FOUND);
+    }
 
   }
+
+  @Nested
+  @DisplayName("신고글 리스트 보기")
+  class getCsList {
+
+    @Test
+    @DisplayName("성공 - 신고글 리스트 보기")
+    void successGetList() {
+      //given
+      MemberEntity member = createMember(1L, Role.USER);
+      List<CsEntity> csList = new ArrayList<>();
+      int page = 1;
+
+
+      for (int i = 20; i < 40; i ++) {
+        String title = "this is title " + i;
+        String content = "this is content" + i;
+
+        csList.add(createCS(Long.valueOf(i), title,content, member, CsStatus.REGISTERED));
+      }
+
+      //when
+      when(memberRepository.findById(member.getMemberId())).thenReturn(Optional.of(member));
+
+      when(csRepository.findAllByMemberEntityOrderByUpdatedAtDesc(member,
+          PageRequest.of(page - 1, 20)))
+          .thenReturn(new PageImpl<>(csList));
+
+      CsListDto response = csService.getCsList(MemberDto.fromEntity(member), page);
+
+      //then
+      assertThat(response.getPageNum()).isEqualTo(page);
+      assertThat(response.getAllElementsCount()).isEqualTo(20);
+
+      int id = 20;
+      for (CsDto cs : response.getCsList()) {
+        assertThat(cs.getCsId()).isEqualTo(id++);
+      }
+    }
+
+    @Test
+    @DisplayName("실패 - 없는 페이지")
+    void failGetListNoPage() {
+      //given
+      MemberEntity member = createMember(1L, Role.USER);
+      List<CsEntity> csList = new ArrayList<>();
+      int page = 3;
+
+
+      for (int i = 20; i < 40; i ++) {
+        String title = "this is title " + i;
+        String content = "this is content" + i;
+
+        csList.add(createCS(Long.valueOf(i), title,content, member, CsStatus.REGISTERED));
+      }
+
+      //when
+      when(memberRepository.findById(member.getMemberId())).thenReturn(Optional.of(member));
+
+      when(csRepository.findAllByMemberEntityOrderByUpdatedAtDesc(member,
+          PageRequest.of(page - 1, 20)))
+          .thenReturn(new PageImpl<>(csList));
+
+      CsException response = catchThrowableOfType(() ->
+          csService.getCsList(MemberDto.fromEntity(member), page),
+          CsException.class);
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.PAGE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패 - 맴버를 찾을 수 없음")
+    void failGetListNoMember() {
+      //given
+      MemberEntity member = createMember(1L, Role.USER);
+      int page = 3;
+
+      //when
+      when(memberRepository.findById(member.getMemberId())).thenReturn(Optional.empty());
+
+      MemberException response = catchThrowableOfType(() ->
+              csService.getCsList(MemberDto.fromEntity(member), page),
+          MemberException.class);
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+    }
+  }
+
+  @Nested
+  @DisplayName("신고글 보기 - 어드민")
+  class getCsListAdmin{
+    @Test
+    @DisplayName("성공 - 어드민 신고글 리스트 가져오기, 모두 null")
+    void successGetCsListAdmin() {
+      //given
+      MemberEntity admin = createMember(1L, Role.ADMIN);
+      MemberEntity user = createMember(11L, Role.USER);
+
+      String email = null;
+      String statusNum = null;
+      int page = 1;
+
+      List<CsEntity> csList = new ArrayList<>();
+
+      for (int i = 20; i < 40; i ++) {
+        String title = "this is title " + i;
+        String content = "this is content" + i;
+
+        csList.add(createCS(Long.valueOf(i), title,content, user, CsStatus.REGISTERED));
+      }
+
+      //when
+      when(csRepository.findAllByConditionsFromAdmin(
+          null, null, PageRequest.of(page - 1, 20)
+      )).thenReturn(new PageImpl<>(csList));
+
+      CsListDto response = csService.getCsListAdmin(
+          MemberDto.fromEntity(admin),null,null,1);
+
+      //then
+      assertThat(response.getPageNum()).isEqualTo(page);
+      assertThat(response.getAllElementsCount()).isEqualTo(20);
+
+      int id = 20;
+      for (CsDto cs : response.getCsList()) {
+        assertThat(cs.getCsId()).isEqualTo(id++);
+      }
+    }
+
+    @Test
+    @DisplayName("성공 - 어드민 신고글 리스트 가져오기, 모두 email")
+    void successGetCsListAdminEmail() {
+      //given
+      MemberEntity admin = createMember(1L, Role.ADMIN);
+      MemberEntity user = createMember(11L, Role.USER);
+      MemberEntity user2 = createMember(111L, Role.USER);
+
+      String email = user2.getEmail();
+      String statusNum = null;
+      int page = 1;
+
+      List<CsEntity> csList = new ArrayList<>();
+      List<CsEntity> csList2 = new ArrayList<>();
+
+      for (int i = 20; i < 40; i ++) {
+        String title = "this is title " + i;
+        String content = "this is content" + i;
+
+        csList.add(createCS(Long.valueOf(i), title,content, user, CsStatus.REGISTERED));
+      }
+
+      for (int i = 40; i < 60; i ++) {
+        String title = "this is title " + i;
+        String content = "this is content" + i;
+
+        csList.add(createCS(Long.valueOf(i), title,content, user2, CsStatus.REGISTERED));
+      }
+
+
+      for (int i = 40; i < 60; i ++) {
+        String title = "this is title " + i;
+        String content = "this is content" + i;
+
+        csList2.add(createCS(Long.valueOf(i), title,content, user2, CsStatus.REGISTERED));
+      }
+
+      //when
+
+      when(memberRepository.findByEmail(email)).thenReturn(Optional.of(user2));
+
+      when(csRepository.findAllByConditionsFromAdmin(
+          user2, null, PageRequest.of(page - 1, 20)
+      )).thenReturn(new PageImpl<>(csList2));
+
+      CsListDto response = csService.getCsListAdmin(
+          MemberDto.fromEntity(admin), email,null,1);
+
+      //then
+      assertThat(response.getPageNum()).isEqualTo(page);
+      assertThat(response.getAllElementsCount()).isEqualTo(20);
+
+      int id = 40;
+      for (CsDto cs : response.getCsList()) {
+        log.info("{}", cs.getCsId());
+        assertThat(cs.getCsId()).isEqualTo(id++);
+      }
+    }
+
+    @Test
+    @DisplayName("성공 - 어드민 신고글 리스트 가져오기, 모두 email, statusNum")
+    void successGetCsListAdminEmailStatusNum() {
+      //given
+      MemberEntity admin = createMember(1L, Role.ADMIN);
+      MemberEntity user = createMember(11L, Role.USER);
+      MemberEntity user2 = createMember(111L, Role.USER);
+
+      String email = user2.getEmail();
+      String statusNum = "1";
+      int page = 1;
+
+      List<CsEntity> csList = new ArrayList<>();
+      List<CsEntity> csList2 = new ArrayList<>();
+
+      for (int i = 20; i < 40; i ++) {
+        String title = "this is title " + i;
+        String content = "this is content" + i;
+
+        csList.add(createCS(Long.valueOf(i), title,content, user, CsStatus.REGISTERED));
+      }
+
+      for (int i = 40; i < 60; i ++) {
+        String title = "this is title " + i;
+        String content = "this is content" + i;
+
+        csList.add(createCS(Long.valueOf(i), title,content, user2, CsStatus.REGISTERED));
+      }
+
+
+      for (int i = 40; i < 60; i ++) {
+        String title = "this is title " + i;
+        String content = "this is content" + i;
+
+        csList2.add(createCS(Long.valueOf(i), title,content, user2, CsStatus.REGISTERED));
+      }
+
+      //when
+
+      when(memberRepository.findByEmail(email)).thenReturn(Optional.of(user2));
+
+      when(csRepository.findAllByConditionsFromAdmin(
+          user2, CsStatus.REGISTERED, PageRequest.of(page - 1, 20)
+      )).thenReturn(new PageImpl<>(csList2));
+
+      CsListDto response = csService.getCsListAdmin(
+          MemberDto.fromEntity(admin), email, statusNum,1);
+
+      //then
+      assertThat(response.getPageNum()).isEqualTo(page);
+      assertThat(response.getAllElementsCount()).isEqualTo(20);
+
+      int id = 40;
+      for (CsDto cs : response.getCsList()) {
+        log.info("{}", cs.getCsId());
+        assertThat(cs.getCsId()).isEqualTo(id++);
+      }
+    }
+
+    @Test
+    @DisplayName("실패 - 페이지를 찾을 수 없음 ")
+    void failGetCsListAdminPageNotFound() {
+      //given
+      MemberEntity admin = createMember(1L, Role.ADMIN);
+      MemberEntity user = createMember(11L, Role.USER);
+
+      int page = 2;
+
+      List<CsEntity> csList = new ArrayList<>();
+
+      for (int i = 20; i < 40; i ++) {
+        String title = "this is title " + i;
+        String content = "this is content" + i;
+
+        csList.add(createCS(Long.valueOf(i), title,content, user, CsStatus.REGISTERED));
+      }
+
+      //when
+      when(csRepository.findAllByConditionsFromAdmin(
+          null, null, PageRequest.of(page - 1, 20)
+      )).thenReturn(new PageImpl<>(csList));
+
+      CsException response = catchThrowableOfType(() -> csService.getCsListAdmin(
+          MemberDto.fromEntity(admin),null,null,page), CsException.class);
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.PAGE_NOT_FOUND);
+
+    }
+
+    @Test
+    @DisplayName("실패 - 어드민이 아님")
+    void failGetCsListAdminNotAdmin() {
+      //given
+      MemberEntity user = createMember(11L, Role.USER);
+
+      int page = 1;
+
+      //when
+
+      MemberException response = catchThrowableOfType(() -> csService.getCsListAdmin(
+          MemberDto.fromEntity(user),null,null, page), MemberException.class);
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.NO_AUTHORITY_ERROR);
+
+    }
+  }
+
+  @Nested
+  @DisplayName("신고글 상태 바꾸기")
+  class changeCsStatus{
+    @Test
+    @DisplayName("성공 - 신고글 상태 바꾸기 성공")
+    void successChangeCs() {
+      //given
+      String title = "this is title";
+      String content = "this is content";
+
+      ChangeStatusDto.Request request = ChangeStatusDto.Request.builder()
+          .statusNum(2)
+          .build();
+
+      MemberEntity member = createMember(1L, Role.ADMIN);
+
+      CsEntity cs = createCS(111L, title, content, member, CsStatus.REGISTERED);
+      CsEntity csAfter = createCS(111L, title, content, member, CsStatus.ING);
+
+      //when
+      when(csRepository.findById(111L)).thenReturn(Optional.of(cs));
+
+      ChangeStatusDto.Response response =
+          csService.changeCsStatus(request, 111L, MemberDto.fromEntity(member));
+
+      //then
+      assertThat(response.getCsStatus()).isEqualTo(csAfter.getCsStatus().getDescription());
+      assertThat(response.getMessage()).isEqualTo(CsConstant.CS_STATUS_SUCCESSFULLY_CHANGED);
+    }
+
+    @Test
+    @DisplayName("실패 - 신고글 상태 입력 실패")
+    void failChangeCsWrongInput() {
+      //given
+      String title = "this is title";
+      String content = "this is content";
+
+      ChangeStatusDto.Request request = ChangeStatusDto.Request.builder()
+          .statusNum(5)
+          .build();
+
+      MemberEntity member = createMember(1L, Role.ADMIN);
+
+      CsEntity cs = createCS(111L, title, content, member, CsStatus.REGISTERED);
+
+      //when
+      when(csRepository.findById(111L)).thenReturn(Optional.of(cs));
+
+      CsException response = catchThrowableOfType(
+          () -> csService.changeCsStatus(request, 111L, MemberDto.fromEntity(member)),
+          CsException.class
+      );
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.INPUT_VALUE_NOT_EXIST_FOR_CS_STATUS);
+    }
+
+    @Test
+    @DisplayName("실패 - 신고글 찾을 수 없음")
+    void failChangeCsNotFound() {
+      //given
+      String title = "this is title";
+      String content = "this is content";
+
+      ChangeStatusDto.Request request = ChangeStatusDto.Request.builder()
+          .statusNum(5)
+          .build();
+
+      MemberEntity member = createMember(1L, Role.ADMIN);
+
+      CsEntity cs = createCS(111L, title, content, member, CsStatus.REGISTERED);
+
+      //when
+      when(csRepository.findById(111L)).thenReturn(Optional.empty());
+
+      CsException response = catchThrowableOfType(
+          () -> csService.changeCsStatus(request, 111L, MemberDto.fromEntity(member)),
+          CsException.class
+      );
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.NO_CS_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패 - 어드민이 아님")
+    void failChangeCsNotAdmin() {
+      //given
+      ChangeStatusDto.Request request = ChangeStatusDto.Request.builder()
+          .statusNum(5)
+          .build();
+
+      MemberEntity member = createMember(1L, Role.USER);
+
+      //when
+
+      MemberException response = catchThrowableOfType(
+          () -> csService.changeCsStatus(request, 111L, MemberDto.fromEntity(member)),
+          MemberException.class
+      );
+
+      //then
+      assertThat(response.getErrorCode()).isEqualTo(ErrorCode.NO_AUTHORITY_ERROR);
+    }
+
+  }
+
 }

--- a/src/test/java/com/anonymous/usports/domain/customerservice/service/impl/CsServiceImplTest.java
+++ b/src/test/java/com/anonymous/usports/domain/customerservice/service/impl/CsServiceImplTest.java
@@ -1,7 +1,12 @@
 package com.anonymous.usports.domain.customerservice.service.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.anonymous.usports.domain.customerservice.dto.RegisterCS;
 import com.anonymous.usports.domain.customerservice.entity.CsEntity;
 import com.anonymous.usports.domain.customerservice.repository.CsRepository;
+import com.anonymous.usports.domain.member.dto.MemberDto;
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.member.repository.MemberRepository;
 import com.anonymous.usports.global.type.CsStatus;
@@ -9,7 +14,11 @@ import com.anonymous.usports.global.type.Gender;
 import com.anonymous.usports.global.type.Role;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -28,7 +37,7 @@ public class CsServiceImplTest {
   @InjectMocks
   private CsServiceImpl csService;
 
-  private MemberEntity createMember(Long id) {
+  private MemberEntity createMember(Long id, Role role) {
     return MemberEntity.builder()
         .memberId(id)
         .accountName("accountName" + id)
@@ -38,25 +47,95 @@ public class CsServiceImplTest {
         .phoneNumber("010-1111-2222")
         .birthDate(LocalDate.now())
         .gender(Gender.MALE)
-        .role(Role.USER)
+        .role(role)
         .profileOpen(true)
         .build();
   }
 
-  private CsEntity createCS(Long id, MemberEntity member,CsStatus csStatus) {
+  private CsEntity createCS(Long id, String title, String content, MemberEntity member,CsStatus csStatus) {
     return CsEntity.builder()
         .csId(id)
         .memberEntity(member)
-        .title("this is title " + id)
-        .content("this is content " + id)
+        .title(title)
+        .content(content)
         .registeredAt(LocalDateTime.now())
         .updatedAt(LocalDateTime.now())
         .csStatus(csStatus)
         .build();
   }
 
+  @Nested
+  @DisplayName("신고글 등록")
+  class registerCS {
+
+    @Test
+    @DisplayName("유저 신고글 등록 성공")
+    void successRegisterCsUSER() {
+      //given
+      String title = "제목입니다";
+      String content = "내용입니다";
+
+      RegisterCS.Request request = RegisterCS.Request.builder()
+          .title(title)
+          .content(content)
+          .build();
+
+      MemberEntity member = createMember(1L, Role.USER);
+
+      CsEntity cs = createCS(5L, title, content,  member,  CsStatus.REGISTERED);
+
+      //when
+      when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+      when(csRepository.save(CsEntity.builder()
+              .title(request.getTitle())
+              .content(request.getContent())
+              .memberEntity(member)
+              .csStatus(CsStatus.REGISTERED)
+          .build())).thenReturn(cs);
+
+      RegisterCS.Response response =
+          csService.registerCs(request, MemberDto.fromEntity(member));
+
+      //then
+      assertThat(response.getContent()).isEqualTo(content);
+      assertThat(response.getTitle()).isEqualTo(title);
+      assertThat(response.getStatus()).isEqualTo(CsStatus.REGISTERED.getDescription());
+    }
+
+    @Test
+    @DisplayName("어드민 신고글 기록 성공")
+    void successRegisterCsADMIN() {
+      //given
+      String title = "제목입니다";
+      String content = "내용입니다";
+
+      RegisterCS.Request request = RegisterCS.Request.builder()
+          .title(title)
+          .content(content)
+          .build();
+
+      MemberEntity member = createMember(1L, Role.ADMIN);
+
+      CsEntity cs = createCS(5L, title, content,  member,  CsStatus.REGISTERED);
+
+      //when
+      when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+      when(csRepository.save(CsEntity.builder()
+          .title(request.getTitle())
+          .content(request.getContent())
+          .memberEntity(member)
+          .csStatus(CsStatus.REGISTERED)
+          .build())).thenReturn(cs);
+
+      RegisterCS.Response response =
+          csService.registerCs(request, MemberDto.fromEntity(member));
+
+      //then
+      assertThat(response.getContent()).isEqualTo(content);
+      assertThat(response.getTitle()).isEqualTo(title);
+      assertThat(response.getStatus()).isEqualTo(CsStatus.REGISTERED.getDescription());
+    }
 
 
-
-
+  }
 }

--- a/src/test/java/com/anonymous/usports/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/anonymous/usports/domain/member/controller/MemberControllerTest.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(MemberContoller.class)
+@WebMvcTest(MemberController.class)
 public class MemberControllerTest {
 
     @MockBean


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
***[신고 등록]***

http://localhost:8080/cs/register

USER 또는 ADMIN이 신고를 할 수 있음

Controller에서 유저 권한을 확인 후, registerCs DTO를 통해서 요청 값을 서버에 넘긴다.

요청 값이 모두 작성이 되야, DB에 저장이 된다

**테스트**

- 신고 등록 성공 테스트 - USER 권한을 가진 유저가 신고를 등록할 때
- 신고 등록 성공 테스트 - ADMIN 권한을 가진 유저가 신고를 등록할 때
- 신고 등록 실패 테스트 - UNAUTH 권한을 가진 유저가 신고를 등록하려고 할 때

***[신고 삭제]***

[http://localhost:8080/cs/delete/{cs_id}](http://localhost:8080/cs/delete/%7Bcs_id%7D)

USER는 자신의 글만 삭제할 수 있다

ADMIN은 모든 글을 삭제할 수 있다 (부적절한 글이 있을 경우)

PathVariable로 글 ID를 받아서, 해당 글을 삭제하는 것

**********테스트**********

- 신고 삭제 성공 테스트 - USER 권한을 가진 유저가 자신의 신고를 삭제할 때
- 신고 삭제 성공 테스트 - ADMIN 권한을 가진 유저가 다른 신고를 삭제할 때 + 자신의 신고를 삭제할 때
- 신고 실패 테스트 - USER 권한을 가진 유저가 다른 신고를 삭제할 때
- 신고 실패 테스트 - 다른 권한을 가진 유저가 신고를 삭제하려고 할

***[신고 수정]***

[http://localhost:8080/cs/update/{cs_id}](http://localhost:8080/cs/update/%7Bcs_id%7D)

수정글은 로그인한 사람의 글만 수정을 할 수 있다

어드민도 다른 사람의 신고글을 수정할 수 없다

**********테스트**********

- 신고 수정 성공 테스트 - 자신의 신고를 수정
- 신고 수정 실패 테스트 - 다른 사람의 신고를 수정하려고 할 때 (USER)
- 신고 수정 실패 테스트 - 다른 사람의 신고를 수정하려고 할 때 (ADMIN)

***[신고글 자세히 보기]***

[http://localhost:8080/cs/{cs_id}](http://localhost:8080/cs/%7Bcs_id%7D)

USER와 ADMIN만 볼 수 있다

**테스트**

- 신고글 자세히 보기 성공 테스트 - 신고글에 대한 내용이 나옴
- 신고글 자세히 보기 실패 테스트 - 신고글 ID가 없음
- 신고글 자세히 보기 실패 테스트 - UNAUTH 권한 유저가 신고글을 보려고 할 때
- 신고글 자세히 보기 실패 테스트 - 로그인이 안 된 유저가 신고글을 보려고 할

***[신고글 리스트 보기]***

http://localhost:8080/cs?page=

현재 로그인한 사람이 작성한 모든 신고글 리스트 보기 (페이지로)

**테스트**

- 신고글 리스트 성공 테스트 - 페이지 리스트를 리턴
- 신고글 리스트 실패 테스트 - 없는 페이지
- 신고글 리스트 실패 테스트 - 로그인이 안 되어 있음

***[신고글 찾기 (어드민)]***

http://localhost:8080/cs/admin

어드민은 모든 신고글 리스트를 볼 수 있다

최신 순으로 정렬이 되어 있고 한 페이지 당 20개의 신고들을 들어가 있다

**테스트**

- 신고글 찾기 (어드민) 성공 테스트 - parameter에 아무것도 없이 검색
- 신고글 찾기 (어드민) 성공 테스트 - parameter에 email, status, page 등을 넣어서 검색
- 신고글 찾기 (어드민) 실패 테스트 - 유저가 해당 url을 사용하려고 할

***[신고글 상태 바꾸기 (어드민)]***

[http://localhost:8080/cs/admin/{cs_id}](http://localhost:8080/cs/admin/%7Bcs_id%7D)

신고글 상태를 바꾸는 것이다.

어드민만 바꿀 수 있고, 현재 신고에 대해 진행 상황을 표시해주는 것이다.

유저가 신고를 했으면 REGISTERED

유저에 신고를 어드민이 해결 중이면 ING

유저에 신고에 대해 해결을 완료했으면 FINISHED으로 저장한다

**테스트**

- 신고글 상태 바꾸기 성공 테스트 - 어드민이 신고글 상태 바꾸기 성공
- 신고글 상태 바꾸기 실패 테스트 - USER가 신고글 상태를 바꾸려고 할 때
- 신고글 상태 바꾸기 실패 테스트 
- 어드민이 신고글 상태 외에 다른 입력값을 입력했을 때
- 신고글 상태 바꾸기 실패 테스트 - 신고글을 찾을 수 없을


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

