### PR TITLE
Refactor: 프로필 - 회원 정보에서 팔로우 상태 정보 포함

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/controller/ProfileController.java
@@ -1,5 +1,6 @@
 package com.anonymous.usports.domain.profile.controller;
 
+import com.anonymous.usports.domain.member.dto.MemberDto;
 import com.anonymous.usports.domain.profile.dto.MemberProfile;
 import com.anonymous.usports.domain.profile.service.ProfileService;
 import com.anonymous.usports.domain.record.dto.RecordListDto;
@@ -9,6 +10,7 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -25,9 +27,10 @@ public class ProfileController {
   @ApiOperation("프로필 - 회원 정보")
   @GetMapping("/profile/{accountName}")
   public ResponseEntity<MemberProfile> profileRecruits(
-      @PathVariable String accountName) {
+      @PathVariable String accountName,
+      @AuthenticationPrincipal MemberDto loginMember) {
 
-    MemberProfile memberProfile = profileService.profileMember(accountName);
+    MemberProfile memberProfile = profileService.profileMember(accountName, loginMember);
 
     return ResponseEntity.ok(memberProfile);
   }

--- a/src/main/java/com/anonymous/usports/domain/profile/dto/MemberProfile.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/dto/MemberProfile.java
@@ -2,6 +2,7 @@ package com.anonymous.usports.domain.profile.dto;
 
 import com.anonymous.usports.domain.mypage.dto.MemberInfo;
 import com.anonymous.usports.domain.sportsskill.dto.SportsSkillDto;
+import com.anonymous.usports.global.type.FollowStatus;
 import java.util.List;
 
 import lombok.AllArgsConstructor;
@@ -20,4 +21,6 @@ public class MemberProfile {
   private MemberInfo memberInfo;
 
   private List<SportsSkillDto> sportsSkills;
+
+  private FollowStatus followStatus;
 }

--- a/src/main/java/com/anonymous/usports/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/service/ProfileService.java
@@ -1,13 +1,14 @@
 package com.anonymous.usports.domain.profile.service;
 
 
+import com.anonymous.usports.domain.member.dto.MemberDto;
 import com.anonymous.usports.domain.profile.dto.MemberProfile;
 import com.anonymous.usports.domain.record.dto.RecordListDto;
 import com.anonymous.usports.domain.recruit.dto.RecruitListDto;
 
 public interface ProfileService {
 
-  MemberProfile profileMember(String accountName);
+  MemberProfile profileMember(String accountName, MemberDto loginMember);
 
   RecordListDto profileRecords(String accountName, Integer page);
 

--- a/src/main/java/com/anonymous/usports/domain/profile/service/impl/ProfileServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/service/impl/ProfileServiceImpl.java
@@ -1,5 +1,8 @@
 package com.anonymous.usports.domain.profile.service.impl;
 
+import com.anonymous.usports.domain.follow.entity.FollowEntity;
+import com.anonymous.usports.domain.follow.repository.FollowRepository;
+import com.anonymous.usports.domain.member.dto.MemberDto;
 import com.anonymous.usports.domain.member.entity.MemberEntity;
 import com.anonymous.usports.domain.member.repository.MemberRepository;
 import com.anonymous.usports.domain.mypage.service.MyPageService;
@@ -15,6 +18,7 @@ import com.anonymous.usports.domain.recruit.entity.RecruitEntity;
 import com.anonymous.usports.global.constant.NumberConstant;
 import com.anonymous.usports.global.exception.ErrorCode;
 import com.anonymous.usports.global.exception.MemberException;
+import com.anonymous.usports.global.type.FollowStatus;
 import com.anonymous.usports.global.type.ParticipantStatus;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,15 +39,26 @@ public class ProfileServiceImpl implements ProfileService {
   private final MemberRepository memberRepository;
   private final RecordRepository recordRepository;
   private final ParticipantRepository participantRepository;
+  private final FollowRepository followRepository;
 
   @Override
-  public MemberProfile profileMember(String accountName) {
+  public MemberProfile profileMember(String accountName, MemberDto loginMember) {
     MemberEntity member = memberRepository.findByAccountName(accountName)
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+    MemberEntity loginMemberEntity = memberRepository.findById(loginMember.getMemberId())
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+    FollowEntity follow = followRepository.findByFromMemberAndToMember(loginMemberEntity,member)
+        .orElse(null);
+
+    FollowStatus checkFollow = null;
+    if (follow != null) {
+      checkFollow = follow.getFollowStatus();
+    }
 
     return MemberProfile.builder()
         .memberInfo(myPageService.getMemberInfo(member.getMemberId()))
         .sportsSkills(myPageService.getSportsSkills(member.getMemberId()))
+        .followStatus(checkFollow)
         .build();
   }
 


### PR DESCRIPTION
# 변경사항

## AS-IS

### ['프로필' 회원 정보 메서드에서 팔로우 상태 정보를 포함시켰습니다.]

타인의 프로필 화면에서 팔로우 여부가 필요하기 때문에 팔로우 상태 정보를 포함시키게 되었습니다.

반환되는 MemberProfile에 followStatus 값을 추가했습니다. 
만약 follow가 아닐 경우 null로 반환되며, 
follow 신청은 했지만 아직 수락or거절 되지 않은 경우 'WAITING',
follow 상태인 경우 'ACTIVE'가 반환됩니다.

## TO-BE

# 테스트

### [API 테스트]

follow 상태가 아닌 경우 null이 출력되는 것을 확인하였고, follow 상태에서 ACTIVE 출력을 확인했습니다. 

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 

