### PR TITLE
Refactor: DeleteRecord 와 profileMember 관련 리팩토링

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/comment/repository/CommentRepository.java
@@ -21,6 +21,8 @@ public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
       "ORDER BY COALESCE(c.parentId, c.commentId), c.registeredAt ASC")
   Page<CommentEntity> findAllCommentsByRecordId(@Param("recordId") Long recordId, Pageable pageable);
 
+  void deleteAllByRecord(RecordEntity recordEntity);
+
 
 
 

--- a/src/main/java/com/anonymous/usports/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/controller/ProfileController.java
@@ -26,7 +26,7 @@ public class ProfileController {
 
   @ApiOperation("프로필 - 회원 정보")
   @GetMapping("/profile/{accountName}")
-  public ResponseEntity<MemberProfile> profileRecruits(
+  public ResponseEntity<MemberProfile> profileMember(
       @PathVariable String accountName,
       @AuthenticationPrincipal MemberDto loginMember) {
 

--- a/src/main/java/com/anonymous/usports/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/controller/ProfileController.java
@@ -30,7 +30,7 @@ public class ProfileController {
       @PathVariable String accountName,
       @AuthenticationPrincipal MemberDto loginMember) {
 
-    MemberProfile memberProfile = profileService.profileMember(accountName, loginMember);
+    MemberProfile memberProfile = profileService.profileMember(accountName, loginMember.getMemberId());
 
     return ResponseEntity.ok(memberProfile);
   }

--- a/src/main/java/com/anonymous/usports/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/service/ProfileService.java
@@ -8,7 +8,7 @@ import com.anonymous.usports.domain.recruit.dto.RecruitListDto;
 
 public interface ProfileService {
 
-  MemberProfile profileMember(String accountName, MemberDto loginMember);
+  MemberProfile profileMember(String accountName, Long loginMemberId);
 
   RecordListDto profileRecords(String accountName, Integer page);
 

--- a/src/main/java/com/anonymous/usports/domain/profile/service/impl/ProfileServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/profile/service/impl/ProfileServiceImpl.java
@@ -42,10 +42,10 @@ public class ProfileServiceImpl implements ProfileService {
   private final FollowRepository followRepository;
 
   @Override
-  public MemberProfile profileMember(String accountName, MemberDto loginMember) {
+  public MemberProfile profileMember(String accountName, Long loginMemberId) {
     MemberEntity member = memberRepository.findByAccountName(accountName)
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
-    MemberEntity loginMemberEntity = memberRepository.findById(loginMember.getMemberId())
+    MemberEntity loginMemberEntity = memberRepository.findById(loginMemberId)
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
     FollowEntity follow = followRepository.findByFromMemberAndToMember(loginMemberEntity,member)
         .orElse(null);

--- a/src/main/java/com/anonymous/usports/domain/record/service/impl/RecordServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/record/service/impl/RecordServiceImpl.java
@@ -21,6 +21,7 @@ import com.anonymous.usports.domain.record.dto.RecordUpdate;
 import com.anonymous.usports.domain.record.entity.RecordEntity;
 import com.anonymous.usports.domain.record.repository.RecordRepository;
 import com.anonymous.usports.domain.record.service.RecordService;
+import com.anonymous.usports.domain.recordlike.repository.RecordLikeRepository;
 import com.anonymous.usports.domain.sports.entity.SportsEntity;
 import com.anonymous.usports.domain.sports.repository.SportsRepository;
 import com.anonymous.usports.global.constant.NumberConstant;
@@ -70,6 +71,7 @@ public class RecordServiceImpl implements RecordService {
   private final InterestedSportsRepository interestedSportsRepository;
   private final FollowRepository followRepository;
   private final CommentRepository commentRepository;
+  private final RecordLikeRepository recordLikeRepository;
   private final AmazonS3 amazonS3;
   @Value("${cloud.aws.s3.bucketName}")
   private String bucketName;
@@ -312,8 +314,13 @@ public class RecordServiceImpl implements RecordService {
         redisTemplate.opsForList()
             .rightPush(URLS_TO_DELETE, recordImageAddress); //redis에 제거할 imageUrl 넣기
       }
+
+      commentRepository.deleteAllByRecord(recordEntity); //댓글 제거
+      recordLikeRepository.deleteAllByRecord(recordEntity); // 좋아요 제거
       recordRepository.delete(recordEntity);// 기록 제거
+
       return RecordDto.fromEntity(recordEntity);
+
     } catch (RecordException e) {
       rollbackUrls(removeImageAddress); //redis에 넣은 제거할 url들을 제거
       throw new RecordException(e.getErrorCode(),e.getErrorMessage());

--- a/src/main/java/com/anonymous/usports/domain/recordlike/repository/RecordLikeRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/recordlike/repository/RecordLikeRepository.java
@@ -12,4 +12,6 @@ public interface RecordLikeRepository extends JpaRepository<RecordLikeEntity, Lo
 
   Optional<RecordLikeEntity> findByRecordAndMember(RecordEntity record, MemberEntity loginMember);
 
+  void deleteAllByRecord(RecordEntity recordEntity);
+
 }


### PR DESCRIPTION
# 변경사항

## AS-IS
<br>

***['프로필 - 회원정보' 메서드 이름 변경]***

ProfileController에 profileRecruits가 2개여서 '프로필 - 회원정보' 메서드의 명칭을 profileMember로 수정했습니다.

<br>
<br>

***[profileMember에서 MemberDto 대신 MemberId 값을 넘기도록 수정]***

기존에 MemberDto 자체를 넘겼으나 Long 값인 MemberId를 넘기는 것으로 수정했습니다.

<br>
<br>

***[deleteRecord 부분에 Comment와 RecordLike를 삭제하는 부분 추가]***

deleteRecord 부분에 Comment와 RecordLike를 삭제하는 부분이 누락되어서 추가했습니다.


## TO-BE

<br>

# 테스트

<br>

***[API 테스트]***

Record에 댓글과 대댓글, 좋아요를 추가한 후 삭제 기능이 정상적으로 작동함을 확인했습니다.

- [ ] 테스트 코드
- [x] API 테스트 

