### PR TITLE
Refactor: Dto 누락 및 네이밍 수정, Test 코드 수정

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/record/dto/RecordDto.java
+++ b/src/main/java/com/anonymous/usports/domain/record/dto/RecordDto.java
@@ -44,6 +44,8 @@ public class RecordDto {
 
   private List<CommentDto> commentList;
 
+  private Long countRecordLike;
+
 
   public static RecordDto fromEntity(RecordEntity recordEntity) {
     return RecordDto.builder()
@@ -58,10 +60,11 @@ public class RecordDto {
         .updatedAt(recordEntity.getUpdatedAt())
         .countComment(recordEntity.getCountComment())
         .imageAddressList(recordEntity.getImageAddress())
+        .countRecordLike(recordEntity.getCountRecordLikes())
         .build();
   }
 
-  public static RecordDto fromEntityInclueComment(RecordEntity recordEntity, Page<CommentEntity> commentList) {
+  public static RecordDto fromEntityIncludeComment(RecordEntity recordEntity, Page<CommentEntity> commentList) {
     return RecordDto.builder()
         .recordId(recordEntity.getRecordId())
         .memberId(recordEntity.getMember().getMemberId())
@@ -76,6 +79,7 @@ public class RecordDto {
         .imageAddressList(recordEntity.getImageAddress())
         .commentList(commentList.getContent().stream().map(CommentDto::fromEntity).collect(
             Collectors.toList()))
+        .countRecordLike(recordEntity.getCountRecordLikes())
         .build();
   }
 }

--- a/src/main/java/com/anonymous/usports/domain/record/service/impl/RecordServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/record/service/impl/RecordServiceImpl.java
@@ -340,7 +340,7 @@ public class RecordServiceImpl implements RecordService {
         .orElseThrow(() -> new RecordException(ErrorCode.RECORD_NOT_FOUND));
     PageRequest pageRequest = PageRequest.of(page - 1, NumberConstant.COMMENT_PAGE_SIZE_DEFAULT);
     Page<CommentEntity> commentList = commentRepository.findAllCommentsByRecordId(recordId,pageRequest);
-    return RecordDto.fromEntityInclueComment(record,commentList);
+    return RecordDto.fromEntityIncludeComment(record,commentList);
   }
 
   /**

--- a/src/test/java/com/anonymous/usports/domain/chatroom/service/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/anonymous/usports/domain/chatroom/service/ChatRoomServiceImplTest.java
@@ -32,6 +32,7 @@ import com.anonymous.usports.websocket.entity.ChatPartakeEntity;
 import com.anonymous.usports.websocket.entity.ChatRoomEntity;
 import com.anonymous.usports.websocket.repository.ChatPartakeRepository;
 import com.anonymous.usports.websocket.repository.ChatRoomRepository;
+import com.anonymous.usports.websocket.repository.ChattingRepository;
 import com.anonymous.usports.websocket.service.impl.ChatRoomServiceImpl;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -67,6 +68,9 @@ public class ChatRoomServiceImplTest {
 
     @Mock
     private RecruitRepository recruitRepository;
+
+    @Mock
+    private ChattingRepository chattingRepository;
 
     @InjectMocks
     private ChatRoomServiceImpl chatRoomService;
@@ -883,6 +887,11 @@ public class ChatRoomServiceImplTest {
             //when
             when(memberRepository.findById(1L)).thenReturn(Optional.ofNullable(member));
             when(chatPartakeRepository.findAllByMemberEntity(member)).thenReturn(chatPartakeList);
+            when(chattingRepository.countAllByChatRoomIdAndIdGreaterThan(3L,null)).thenReturn(0L);
+            when(chattingRepository.countAllByChatRoomIdAndIdGreaterThan(33L,null)).thenReturn(0L);
+            when(chattingRepository.countAllByChatRoomIdAndIdGreaterThan(333L,null)).thenReturn(0L);
+            when(chattingRepository.countAllByChatRoomIdAndIdGreaterThan(3333L,null)).thenReturn(0L);
+
 
             List<ChatPartakeDto> chatPartakes = chatRoomService.getChatRoomList(MemberDto.fromEntity(member));
 


### PR DESCRIPTION
### 변경사항

**AS-IS**

**[RecordDto에 countRecordLike 추가했습니다.]**

DB에는 기존에 있었으나 RecordDto에 누락되었던 countRecordLike를 추가했습니다.

**[RecordDto에 fromEntityInclueComment 네이밍 변경]**

fromEntityInclueComment 에 오타가 있어 fromEntityIncludeComment로 변경했습니다.

**[ChattingRoomServiceTest 수정]**

getChattingRoomList에서 읽지 않은 채팅 수를 가져오는 부분을 추가했는데 해당 부분에 대한 테스트 코드를 수정하지 않았던 부분을 추가했습니다. 

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 

