### PR TITLE
Refactore/oauth

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/member/controller/OAuthController.java
+++ b/src/main/java/com/anonymous/usports/domain/member/controller/OAuthController.java
@@ -1,17 +1,17 @@
 package com.anonymous.usports.domain.member.controller;
 
+import com.anonymous.usports.domain.member.dto.MemberLogin;
 import com.anonymous.usports.domain.member.service.impl.CustomOAuth2MemberService;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Api(tags = "OAuth2")
-@Controller
-@RequestMapping("/login")
+@RestController
+@RequestMapping("/oauth2/login")
 @RequiredArgsConstructor
 @Slf4j
 public class OAuthController {
@@ -21,10 +21,20 @@ public class OAuthController {
     /**
      * 테스트 용
      */
-    @GetMapping("")
-    public String login(Model model){
-
-        log.info("hello");
-        return "login";
+    @GetMapping("/success")
+    public MemberLogin.Response loginSuccess(){
+        return MemberLogin.Response.builder()
+            .tokenDto()
+            .memberResponse()
+            .build();
     }
+//    @GetMapping("/code/{registrationId}")
+//    public String login(
+//        @RequestParam String code,
+//        @RequestParam String state,
+//        @PathVariable String registrationId
+//    ){
+//
+//        return code;
+//    }
 }

--- a/src/main/java/com/anonymous/usports/domain/member/controller/OAuthController.java
+++ b/src/main/java/com/anonymous/usports/domain/member/controller/OAuthController.java
@@ -1,10 +1,12 @@
 package com.anonymous.usports.domain.member.controller;
 
-import com.anonymous.usports.domain.member.dto.MemberLogin;
-import com.anonymous.usports.domain.member.service.impl.CustomOAuth2MemberService;
+import com.anonymous.usports.domain.member.dto.MemberDto;
+import com.anonymous.usports.domain.member.dto.frontResponse.MemberResponse;
+import com.anonymous.usports.domain.member.service.impl.MemberServiceImpl;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,25 +18,13 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class OAuthController {
 
-    private final CustomOAuth2MemberService customOAuth2MemberService;
+    private final MemberServiceImpl memberService;
 
-    /**
-     * 테스트 용
-     */
     @GetMapping("/success")
-    public MemberLogin.Response loginSuccess(){
-        return MemberLogin.Response.builder()
-            .tokenDto()
-            .memberResponse()
-            .build();
+    public MemberResponse oauthLogin(
+        @AuthenticationPrincipal MemberDto memberDto
+    ) {
+        return memberService.oauthLogin(memberDto.getMemberId());
     }
-//    @GetMapping("/code/{registrationId}")
-//    public String login(
-//        @RequestParam String code,
-//        @RequestParam String state,
-//        @PathVariable String registrationId
-//    ){
-//
-//        return code;
-//    }
+
 }

--- a/src/main/java/com/anonymous/usports/domain/member/security/SecurityConfig.java
+++ b/src/main/java/com/anonymous/usports/domain/member/security/SecurityConfig.java
@@ -20,37 +20,37 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtAuthenticationFilter authenticationFilter;
-    private final CustomOAuth2MemberService customOAuth2MemberService;
-    private final OAuth2SuccessHandler oAuth2SuccessHandler;
-    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
-    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+  private final JwtAuthenticationFilter authenticationFilter;
+  private final CustomOAuth2MemberService customOAuth2MemberService;
+  private final OAuth2SuccessHandler oAuth2SuccessHandler;
+  private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+  private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-         http
-                .httpBasic().disable()
-                .csrf().disable()
-                .cors().and()
-                .headers().frameOptions().disable();
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        .httpBasic().disable()
+        .csrf().disable()
+        .cors().and()
+        .headers().frameOptions().disable();
 
-         http
-                .authorizeRequests()
-                .antMatchers("/**").permitAll();
+    http
+        .authorizeRequests()
+        .antMatchers("/**").permitAll();
 
-         http
-                 .oauth2Login().loginPage("/login")
-                 .userInfoEndpoint().userService(customOAuth2MemberService)
-                 .and().successHandler(oAuth2SuccessHandler);
+    http
+        .oauth2Login()
+        .userInfoEndpoint().userService(customOAuth2MemberService)
+        .and().defaultSuccessUrl("/oauth/login/success").successHandler(oAuth2SuccessHandler);
 
-         http
-                .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .exceptionHandling()
-                  .authenticationEntryPoint(customAuthenticationEntryPoint)
-                  .accessDeniedHandler(customAccessDeniedHandler);
+    http
+        .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .exceptionHandling()
+        .authenticationEntryPoint(customAuthenticationEntryPoint)
+        .accessDeniedHandler(customAccessDeniedHandler);
 
-        return http.build();
-    }
+    return http.build();
+  }
 
 //    @Bean
 //    public WebSecurityCustomizer webSecurityCustomizer() {
@@ -58,10 +58,10 @@ public class SecurityConfig {
 //    }
 
 
-    @Bean
-    public AuthenticationManager authenticationManagerBean(
-            AuthenticationConfiguration authenticationConfiguration) throws Exception {
-        return authenticationConfiguration.getAuthenticationManager();
-    } 
+  @Bean
+  public AuthenticationManager authenticationManagerBean(
+      AuthenticationConfiguration authenticationConfiguration) throws Exception {
+    return authenticationConfiguration.getAuthenticationManager();
+  }
 
 }

--- a/src/main/java/com/anonymous/usports/domain/member/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/anonymous/usports/domain/member/security/handler/OAuth2SuccessHandler.java
@@ -26,7 +26,7 @@ public class OAuth2SuccessHandler  extends SimpleUrlAuthenticationSuccessHandler
 
         TokenDto token = tokenProvider.saveTokenInRedis(memberDto.getEmail());
 
-        log.info("OAuth2 인증 성공");
+        response.addHeader("Authorization", token.getAccessToken());
 
         getRedirectStrategy().sendRedirect(request, response, "http://localhost:8080/oauth2/login/success");
 

--- a/src/main/java/com/anonymous/usports/domain/member/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/anonymous/usports/domain/member/security/handler/OAuth2SuccessHandler.java
@@ -3,16 +3,15 @@ package com.anonymous.usports.domain.member.security.handler;
 import com.anonymous.usports.domain.member.dto.MemberDto;
 import com.anonymous.usports.domain.member.dto.TokenDto;
 import com.anonymous.usports.domain.member.security.TokenProvider;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
@@ -25,12 +24,11 @@ public class OAuth2SuccessHandler  extends SimpleUrlAuthenticationSuccessHandler
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         MemberDto memberDto = (MemberDto) authentication.getPrincipal();
 
-        log.info("{}", memberDto.getAttributes());
-        log.info("OAuth2 인증 성공");
-
         TokenDto token = tokenProvider.saveTokenInRedis(memberDto.getEmail());
 
-        log.info("{}", token.getAccessToken());
-        log.info("{}", token.getRefreshToken());
+        log.info("OAuth2 인증 성공");
+
+        getRedirectStrategy().sendRedirect(request, response, "http://localhost:8080/oauth2/login/success");
+
     }
 }

--- a/src/main/java/com/anonymous/usports/domain/member/service/MemberService.java
+++ b/src/main/java/com/anonymous/usports/domain/member/service/MemberService.java
@@ -26,6 +26,11 @@ public interface MemberService {
     MemberResponse loginMember(MemberLogin.Request request);
 
     /**
+     * 간편 로그인
+     */
+    MemberResponse oauthLogin(Long memberId);
+
+    /**
      * 회원 로그아웃
      */
     String logoutMember(String accessToken, String email);

--- a/src/main/java/com/anonymous/usports/domain/member/service/impl/CustomOAuth2MemberService.java
+++ b/src/main/java/com/anonymous/usports/domain/member/service/impl/CustomOAuth2MemberService.java
@@ -105,4 +105,6 @@ public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
 
         return memberInfo;
     }
+
+
 }

--- a/src/main/java/com/anonymous/usports/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/member/service/impl/MemberServiceImpl.java
@@ -100,6 +100,16 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
     );
   }
 
+  private List<SportsDto> interestSportsList(MemberEntity member) {
+    List<InterestedSportsEntity> interestedSportsEntityList =
+        interestedSportsRepository.findAllByMemberEntity(member);
+
+    return interestedSportsEntityList.stream()
+        .map(InterestedSportsEntity::getSports)
+        .map(SportsDto::new)
+        .collect(Collectors.toList());
+  }
+
   @Override
   public MemberRegister.Response registerMember(MemberRegister.Request request) {
 
@@ -119,6 +129,16 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
 
     return MemberResponse.fromDto(memberDto,
         myPageService.getInterestedSportsList(memberDto.getMemberId()));
+  }
+
+  @Override
+  public MemberResponse oauthLogin(Long memberId) {
+
+    MemberEntity member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+    return MemberResponse.fromDto(MemberDto.fromEntity(member),
+        interestSportsList(member));
   }
 
   @Override
@@ -254,7 +274,7 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
     MemberEntity memberEntity = memberRepository.findById(memberDto.getMemberId())
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
 
-    List<SportsDto> interestedSportsList = myPageService.getInterestedSportsList(memberId);
+    List<SportsDto> interestedSportsList = interestSportsList(memberEntity);
 
     if (!profileImage.isEmpty()) { // 파일 업로드 있을 때 -> 프로필 이미지 등록 및 변경
       String profileImageAddress = saveImage(profileImage); // 프로필 이미지 S3에 저장


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->

[MemberServiceImpl, getInterestedSports 관련]
- MyPageService에서 getInterestedSports에서, 맴버를 한번 찾는다 (즉 findById를 한 번 한다는 것)
- 만약 MemberServiceImpl에서의 특정 매서드에서 이미 맴버를 찾는, findById가 있으면, 사실상 DB를 두 번 들어가야 한다는 것
- 한 번 들어가면 될 것을, 두 번 확인하면, 비효율적이다고 판단해서, 따로 메서드를 생성

```
  private List<SportsDto> interestSportsList(MemberEntity member) {
    List<InterestedSportsEntity> interestedSportsEntityList =
        interestedSportsRepository.findAllByMemberEntity(member);

    return interestedSportsEntityList.stream()
        .map(InterestedSportsEntity::getSports)
        .map(SportsDto::new)
        .collect(Collectors.toList());
  }

 @Override
  public MemberResponse oauthLogin(Long memberId) {

    MemberEntity member = memberRepository.findById(memberId)
        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));

    return MemberResponse.fromDto(MemberDto.fromEntity(member),
        interestSportsList(member));
  }
```

[OAuth2SuccessHandler]
- 백엔드에서만 했을 때에는, 응답 값이 제대로 없었음
- 프론트에서 로그인을 했을 때에, 응답 값을 요청한 것이 있어서, 응답 값을 리턴할 수 있도록 redirect를 해줬다
- redirect를 할 때에, header에 accessToken을 넣어서, 프론트가 필요한 응답 값을 받을 수 있도록 설정을 했다!


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 

