### PR TITLE
Feature/profile image remove

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/member/controller/MemberController.java
+++ b/src/main/java/com/anonymous/usports/domain/member/controller/MemberController.java
@@ -149,17 +149,30 @@ public class MemberController {
   }
 
   /**
-   * 프로필 이미지 등록 / 변경 / 삭제 http://localhost:8080/member/{memberId}/profile-image
+   * 프로필 이미지 등록 / 변경 http://localhost:8080/member/{memberId}/profile-image
    */
   @PutMapping("/{memberId}/profile-image")
   @PreAuthorize("hasAnyRole('ROLE_UNAUTH', 'ROLE_ADMIN', 'ROLE_USER')")
-  @ApiOperation(value = "프로필 이미지 변경, 삭제", notes = "회원 정보 수정과 별개로 프로필 이미지만 변경 및 삭제")
+  @ApiOperation(value = "프로필 이미지 변경", notes = "회원 정보 수정과 별개로 프로필 이미지만 변경")
   public ResponseEntity<MemberResponse> updateMemberProfileImage(
       @PathVariable("memberId") Long id,
       @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
       @AuthenticationPrincipal MemberDto memberDto) {
     return ResponseEntity.ok(
         memberService.updateMemberProfileImage(profileImage, memberDto, id));
+  }
+
+  /**
+   * 프로필 이미지 삭제 http://localhost:8080/member/{memberId}/profile-image/remove
+   */
+  @PutMapping("/{memberId}/profile-image/remove")
+  @PreAuthorize("hasAnyRole('ROLE_UNAUTH', 'ROLE_ADMIN', 'ROLE_USER')")
+  @ApiOperation(value = "프로필 이미지 삭제", notes = "회원 정보 수정과 별개로 프로필 이미지만 삭제")
+  public ResponseEntity<MemberResponse> deleteMemberProfileImage(
+      @PathVariable("memberId") Long id,
+      @AuthenticationPrincipal MemberDto memberDto) {
+    return ResponseEntity.ok(
+        memberService.deleteMemberProfileImage(memberDto, id));
   }
 
   /**

--- a/src/main/java/com/anonymous/usports/domain/member/service/MemberService.java
+++ b/src/main/java/com/anonymous/usports/domain/member/service/MemberService.java
@@ -54,7 +54,7 @@ public interface MemberService {
     /**
      * 프로필 이미지 삭제
      */
-    MemberResponse deleteMemberProfileImage(MemberDto memberDto, Long id);
+    MemberResponse deleteMemberProfileImage(MemberDto memberDto, Long memberId);
 
     /**
      * 회원 비밀번호 수정

--- a/src/main/java/com/anonymous/usports/domain/member/service/MemberService.java
+++ b/src/main/java/com/anonymous/usports/domain/member/service/MemberService.java
@@ -47,9 +47,14 @@ public interface MemberService {
     MemberResponse updateMember(MemberUpdate.Request request, MemberDto memberDto, Long memberId);
 
     /**
-     * 프로필 이미지 변경 / 삭제
+     * 프로필 이미지 변경
      */
     MemberResponse updateMemberProfileImage(MultipartFile profileImage, MemberDto memberDto, Long memberId);
+
+    /**
+     * 프로필 이미지 삭제
+     */
+    MemberResponse deleteMemberProfileImage(MemberDto memberDto, Long id);
 
     /**
      * 회원 비밀번호 수정
@@ -65,6 +70,7 @@ public interface MemberService {
      * 회원 이메일 인증 번호 재전송
      */
     MailResponse resendEmailAuth(MemberDto memberDto, Long memberId);
+
 
 
 }

--- a/src/main/java/com/anonymous/usports/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/member/service/impl/MemberServiceImpl.java
@@ -25,7 +25,6 @@ import com.anonymous.usports.domain.mypage.service.MyPageService;
 import com.anonymous.usports.domain.sports.dto.SportsDto;
 import com.anonymous.usports.domain.sports.repository.SportsRepository;
 import com.anonymous.usports.global.constant.MailConstant;
-import com.anonymous.usports.global.constant.NumberConstant;
 import com.anonymous.usports.global.constant.ResponseConstant;
 import com.anonymous.usports.global.constant.TokenConstant;
 import com.anonymous.usports.global.exception.ErrorCode;
@@ -281,10 +280,6 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
       throw new MemberException(ErrorCode.IMAGE_SAVE_ERROR);
     }
 
-    if (profileImage.getSize() > NumberConstant.MAX_PROFILE_IMAGE_COUNT) {
-      throw new MemberException(ErrorCode.TOO_MANY_IMAGES);
-    }
-
     String profileImageAddress = saveImage(profileImage); // 프로필 이미지 S3에 저장
     if (memberEntity.getProfileImage() != null) {
       deleteImageFromS3(memberEntity.getProfileImage()); // S3에 저장된 기존 프로필 이미지 제거
@@ -297,6 +292,7 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
 
   // 프로필 이미지 삭제
   @Override
+  @Transactional
   public MemberResponse deleteMemberProfileImage(MemberDto memberDto, Long memberId) {
 
     if (memberDto.getRole() != Role.ADMIN && memberDto.getMemberId() != memberId) {

--- a/src/main/java/com/anonymous/usports/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/member/service/impl/MemberServiceImpl.java
@@ -297,7 +297,11 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
 
   // 프로필 이미지 삭제
   @Override
-  public MemberResponse deleteMemberProfileImage(MemberDto memberDto, Long id) {
+  public MemberResponse deleteMemberProfileImage(MemberDto memberDto, Long memberId) {
+
+    if (memberDto.getRole() != Role.ADMIN && memberDto.getMemberId() != memberId) {
+      throw new MemberException(ErrorCode.MEMBER_ID_UNMATCH);
+    }
 
     MemberEntity memberEntity = memberRepository.findById(memberDto.getMemberId())
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/anonymous/usports/global/constant/NumberConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/NumberConstant.java
@@ -3,6 +3,8 @@ package com.anonymous.usports.global.constant;
 public class NumberConstant {
   public static final int MAX_IMAGE_COUNT = 5;
 
+  public static final int MAX_PROFILE_IMAGE_COUNT = 1;
+
   public static final int PAGE_SIZE_SIX = 6;
   public static final int PAGE_SIZE_DEFAULT = 10;
 

--- a/src/main/java/com/anonymous/usports/global/constant/NumberConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/NumberConstant.java
@@ -3,8 +3,6 @@ package com.anonymous.usports.global.constant;
 public class NumberConstant {
   public static final int MAX_IMAGE_COUNT = 5;
 
-  public static final int MAX_PROFILE_IMAGE_COUNT = 1;
-
   public static final int PAGE_SIZE_SIX = 6;
   public static final int PAGE_SIZE_DEFAULT = 10;
 


### PR DESCRIPTION
### 변경사항

**AS-IS**

**[프로필 이미지 삭제 API 추가]**

기존 방식에서는 프로필 이미지 등록, 변경, 삭제를 하나의 API에서 작동했으나, 
FormData의 null 값 사용 불가와 관련된 문제로 인해 프로필 이미지 API를 따로 분리하였습니다.

따라서 기존에 프로필 등록 및 변경에 null일 경우 에러 발생시키는 부분이 추가되었습니다.



**TO-BE**

### 테스트

기존 프로필 사진이 있는 회원에게 프로필 사진 삭제가 작동함을 확인했고, 
프로필 등록 및 변경 메서드에서 프로필 사진값이 null일 경우 예외 발생을 확인했습니다.

- [ ] 테스트 코드
- [x] API 테스트 

