### PR TITLE
Refactor: MemberInfo에 profileOpen 여부 추가

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/mypage/dto/MemberInfo.java
+++ b/src/main/java/com/anonymous/usports/domain/mypage/dto/MemberInfo.java
@@ -29,6 +29,8 @@ public class MemberInfo {
 
   private List<SportsDto> interestSportsList;
 
+  private boolean profileOpen;
+
 
   public MemberInfo(MemberEntity memberEntity, List<SportsDto> interestSportsList){
     this.profileImage = memberEntity.getProfileImage();
@@ -38,6 +40,7 @@ public class MemberInfo {
     this.email = memberEntity.getEmail();
     this.mannerScore = memberEntity.getMannerScore();
     this.interestSportsList = interestSportsList;
+    this.profileOpen = memberEntity.isProfileOpen();
   }
 
 }


### PR DESCRIPTION
### 변경사항

**AS-IS**

**[MemberInfo Dto에 profileOpen 값을 추가]**

프로필 등에서 회원 정보를 가져올 때 사용되는 MemberInfo에 프로필 공개 여부를 알 수 있도록 profileOpen을 추가했습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 

