### PR TITLE
Refactor: accessToken blacklist 수정

### DIFF
--- a/src/main/java/com/anonymous/usports/global/constant/TokenConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/TokenConstant.java
@@ -19,7 +19,7 @@ public class TokenConstant {
     public static final Long ACCESS_TOKEN_VALID_TIME = 60 *60 * 60 * 1000L;
 
     //3일 3 * 24 * 60 * 60L
-    public static final Long REFRESH_TOKEN_VALID_TIME = 3 * 24 * 60 * 60L;
+    public static final Long REFRESH_TOKEN_VALID_TIME = 3 * 24 * 60 * 60 * 1000L;
 
     public static final String KEY_ROLES = "role";
 

--- a/src/main/java/com/anonymous/usports/global/redis/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/anonymous/usports/global/redis/token/repository/RefreshTokenRepository.java
@@ -47,7 +47,7 @@ public class RefreshTokenRepository implements TokenRepository {
         ValueOperations<String, String> values = redisTemplate.opsForValue();
         values.set(TokenConstant.ACCESS_TOKEN_PREFIX + accessToken,
                 TokenConstant.BLACK_LIST,
-                TokenConstant.ACCESS_TOKEN_VALID_TIME);
+                Duration.ofMillis(TokenConstant.ACCESS_TOKEN_VALID_TIME));
     }
 
     /**


### PR DESCRIPTION
### 변경사항

**AS-IS**

**[addBlackListAccessToken 수정]**

AccessToken blacklist에 TTL 값 설정하는 부분에 Duration.ofMillis()를 추가했습니다.

**[REFRESH_TOKEN_VALID_TIME 값 수정]**

기존 refreshToken의 TTL이 5분 정도로 짧았기 때문에 refreshToken의 유효 시간을 3 * 24 * 60 * 60 * 1000L(3일) 로 연장했습니다.



**TO-BE**

### 테스트

- [ ] 테스트 코드
- [x] API 테스트 

