### PR TITLE
Refactor: Follow 신청 시 Waiting 상태 고려

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/follow/repository/FollowRepository.java
@@ -13,11 +13,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface FollowRepository extends JpaRepository<FollowEntity, Long> {
 
-
-
-  Optional<FollowEntity> findByFromMemberAndToMemberAndFollowStatus(MemberEntity fromMember,
-      MemberEntity toMemberId, FollowStatus followStatus);
-
   Page<FollowEntity> findAllByFromMemberAndFollowStatusOrderByFollowDateDesc(MemberEntity member, FollowStatus followStatus, Pageable pageable);
 
   Page<FollowEntity> findAllByToMemberAndFollowStatusOrderByFollowDateDesc(MemberEntity member, FollowStatus followStatus, Pageable pageable);

--- a/src/main/java/com/anonymous/usports/global/constant/ResponseConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/ResponseConstant.java
@@ -33,6 +33,7 @@ public class ResponseConstant {
   //팔로우 관련
   public static final String REGISTER_FOLLOW = "팔로우를 신청했습니다.";
   public static final String DELETE_FOLLOW = "팔로우를 삭제했습니다.";
+  public static final String CANCEL_FOLLOW_REQUEST = "팔로우 신청을 취소했습니다.";
   public static final String ACCEPT_FOLLOW = "팔로우를 수락했습니다.";
   public static final String REFUSE_FOLLOW = "팔로우를 거절했습니다.";
 

--- a/src/test/java/com/anonymous/usports/domain/follow/service/impl/FollowServiceImplTest.java
+++ b/src/test/java/com/anonymous/usports/domain/follow/service/impl/FollowServiceImplTest.java
@@ -92,8 +92,7 @@ class FollowServiceImplTest {
           .thenReturn(Optional.of(fromMember));
       when(memberRepository.findById(2L))
           .thenReturn(Optional.of(toMember));
-      when(followRepository.findByFromMemberAndToMemberAndFollowStatus(fromMember, toMember,
-          FollowStatus.ACTIVE)).thenReturn(Optional.empty());
+      when(followRepository.findByFromMemberAndToMember(fromMember, toMember)).thenReturn(Optional.empty());
 
       FollowResponse response = followService.changeFollow(fromMember.getMemberId(),
           toMember.getMemberId());
@@ -104,8 +103,8 @@ class FollowServiceImplTest {
     }
 
     @Test
-    @DisplayName("성공 - 기존 Follow가 존재할 때 Follow 취소")
-    void success_DeleteFollow() {
+    @DisplayName("성공 - 기존 FollowActive가 존재할 때 Follow 취소")
+    void success_DeleteFollowActive() {
       MemberEntity fromMember = createMember(1L);
       MemberEntity toMember = createMember(2L);
       toMember.setProfileOpen(false);
@@ -115,8 +114,7 @@ class FollowServiceImplTest {
           .thenReturn(Optional.of(fromMember));
       when(memberRepository.findById(2L))
           .thenReturn(Optional.of(toMember));
-      when(followRepository.findByFromMemberAndToMemberAndFollowStatus(fromMember, toMember,
-          FollowStatus.ACTIVE)).thenReturn(Optional.of(follow));
+      when(followRepository.findByFromMemberAndToMember(fromMember, toMember)).thenReturn(Optional.of(follow));
 
       FollowResponse response = followService.changeFollow(fromMember.getMemberId(),
           toMember.getMemberId());
@@ -124,6 +122,30 @@ class FollowServiceImplTest {
       verify(followRepository, times(1)).delete(follow);
 
       assertEquals(response.getMessage(), ResponseConstant.DELETE_FOLLOW);
+    }
+
+
+    @Test
+    @DisplayName("성공 - 기존 FollowWaiting이 존재할 때 Follow 취소")
+    void success_DeleteFollowWaiting() {
+      MemberEntity fromMember = createMember(1L);
+      MemberEntity toMember = createMember(2L);
+      toMember.setProfileOpen(false);
+      FollowEntity follow = createFollow(10L, fromMember, toMember);
+      follow.setFollowStatus(FollowStatus.WAITING);
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(fromMember));
+      when(memberRepository.findById(2L))
+          .thenReturn(Optional.of(toMember));
+      when(followRepository.findByFromMemberAndToMember(fromMember, toMember)).thenReturn(Optional.of(follow));
+
+      FollowResponse response = followService.changeFollow(fromMember.getMemberId(),
+          toMember.getMemberId());
+
+      verify(followRepository, times(1)).delete(follow);
+
+      assertEquals(response.getMessage(), ResponseConstant.CANCEL_FOLLOW_REQUEST);
     }
 
     @Test


### PR DESCRIPTION
### 변경사항

**AS-IS**

**[Follow 신청 시 Waiting 상태 고려]**

기존 follow 신청 시 ACTIVE 상태만 고려해서 취소가 이루어졌다면 이번 수정을 통해 Waiting 상태인 경우의 취소도 추가되었습니다.

기존에 경우에 Waiting 상태를 고려하지 못해 Waiting 인 신청이 있을 경우 계속 follow 신청 버튼을 누르면 새로운 follow가 생겨서 오류가 발생하였습니다.

이번 수정을 통해 그러한 오류의 발생을 막을 수 있을 것입니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

