### PR TITLE
회원 검색 API

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/member/controller/MemberController.java
+++ b/src/main/java/com/anonymous/usports/domain/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.anonymous.usports.domain.member.dto.MailResponse;
 import com.anonymous.usports.domain.member.dto.MemberDto;
 import com.anonymous.usports.domain.member.dto.MemberLogin;
 import com.anonymous.usports.domain.member.dto.MemberRegister;
+import com.anonymous.usports.domain.member.dto.MemberSearchResponse;
 import com.anonymous.usports.domain.member.dto.MemberUpdate;
 import com.anonymous.usports.domain.member.dto.MemberWithdraw;
 import com.anonymous.usports.domain.member.dto.PasswordLostResponse;
@@ -16,6 +17,7 @@ import com.anonymous.usports.domain.member.service.MemberService;
 import com.anonymous.usports.domain.notification.service.NotificationService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -226,4 +228,15 @@ public class MemberController {
     return ResponseEntity.ok(
         memberService.resendEmailAuth(memberDto, id));
   }
+
+  @PreAuthorize("hasAnyRole('ROLE_USER')")
+  @GetMapping("/search")
+  @ApiOperation("회원 검색")
+  public ResponseEntity<List<MemberSearchResponse>> searchMember(@RequestParam String accountName){
+
+    List<MemberSearchResponse> result = memberService.searchMember(accountName);
+
+    return ResponseEntity.ok(result);
+  }
+
 }

--- a/src/main/java/com/anonymous/usports/domain/member/dto/MemberSearchResponse.java
+++ b/src/main/java/com/anonymous/usports/domain/member/dto/MemberSearchResponse.java
@@ -1,0 +1,37 @@
+package com.anonymous.usports.domain.member.dto;
+
+
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MemberSearchResponse {
+
+  private Long memberId;
+
+  private String profileImage;
+
+  private String accountName;
+
+  private String name;
+
+  private String email;
+
+  public static MemberSearchResponse fromEntity(MemberEntity memberEntity){
+    return MemberSearchResponse.builder()
+        .memberId(memberEntity.getMemberId())
+        .profileImage(memberEntity.getProfileImage())
+        .accountName(memberEntity.getAccountName())
+        .name(memberEntity.getName())
+        .email(memberEntity.getEmail())
+        .build();
+  }
+}

--- a/src/main/java/com/anonymous/usports/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.anonymous.usports.domain.member.repository;
 
 import com.anonymous.usports.domain.member.entity.MemberEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -16,6 +17,8 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     Optional<MemberEntity> findByEmail(String email);
 
     Optional<MemberEntity> findByAccountName(String accountName);
+
+    List<MemberEntity> findAllByAccountNameContainingOrderByAccountNameAsc(String accountName);
 
 
 }

--- a/src/main/java/com/anonymous/usports/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/anonymous/usports/domain/member/repository/MemberRepository.java
@@ -18,7 +18,7 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
     Optional<MemberEntity> findByAccountName(String accountName);
 
-    List<MemberEntity> findAllByAccountNameContainingOrderByAccountNameAsc(String accountName);
+    List<MemberEntity> findAllByAccountNameContaining(String accountName);
 
 
 }

--- a/src/main/java/com/anonymous/usports/domain/member/service/MemberService.java
+++ b/src/main/java/com/anonymous/usports/domain/member/service/MemberService.java
@@ -5,11 +5,13 @@ import com.anonymous.usports.domain.member.dto.MailResponse;
 import com.anonymous.usports.domain.member.dto.MemberDto;
 import com.anonymous.usports.domain.member.dto.MemberLogin;
 import com.anonymous.usports.domain.member.dto.MemberRegister;
+import com.anonymous.usports.domain.member.dto.MemberSearchResponse;
 import com.anonymous.usports.domain.member.dto.MemberUpdate;
 import com.anonymous.usports.domain.member.dto.MemberWithdraw;
 import com.anonymous.usports.domain.member.dto.PasswordLostResponse;
 import com.anonymous.usports.domain.member.dto.PasswordUpdate;
 import com.anonymous.usports.domain.member.dto.frontResponse.MemberResponse;
+import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
@@ -79,5 +81,9 @@ public interface MemberService {
    */
   MailResponse resendEmailAuth(MemberDto memberDto, Long memberId);
 
+  /**
+   * 회원 검색
+   */
+  List<MemberSearchResponse> searchMember(String accountName);
 
 }

--- a/src/main/java/com/anonymous/usports/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/member/service/impl/MemberServiceImpl.java
@@ -461,9 +461,10 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
 
   @Override
   public List<MemberSearchResponse> searchMember(String accountName) {
-        return memberRepository.findAllByAccountNameContainingOrderByAccountNameAsc(accountName)
+        return memberRepository.findAllByAccountNameContaining(accountName)
             .stream()
             .map(MemberSearchResponse::fromEntity)
+            .sorted((m1, m2)-> m1.getAccountName().length() - m2.getAccountName().length())
             .collect(Collectors.toList());
   }
 

--- a/src/main/java/com/anonymous/usports/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/member/service/impl/MemberServiceImpl.java
@@ -10,6 +10,7 @@ import com.anonymous.usports.domain.member.dto.MailResponse;
 import com.anonymous.usports.domain.member.dto.MemberDto;
 import com.anonymous.usports.domain.member.dto.MemberLogin;
 import com.anonymous.usports.domain.member.dto.MemberRegister;
+import com.anonymous.usports.domain.member.dto.MemberSearchResponse;
 import com.anonymous.usports.domain.member.dto.MemberUpdate;
 import com.anonymous.usports.domain.member.dto.MemberWithdraw;
 import com.anonymous.usports.domain.member.dto.PasswordLostResponse;
@@ -456,6 +457,14 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
     mailService.sendEmailAuthMail(memberDto.getEmail());
 
     return new MailResponse(MailConstant.AUTH_EMAIL_SEND);
+  }
+
+  @Override
+  public List<MemberSearchResponse> searchMember(String accountName) {
+        return memberRepository.findAllByAccountNameContainingOrderByAccountNameAsc(accountName)
+            .stream()
+            .map(MemberSearchResponse::fromEntity)
+            .collect(Collectors.toList());
   }
 
   @Override

--- a/src/main/java/com/anonymous/usports/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/anonymous/usports/domain/recruit/controller/RecruitController.java
@@ -77,7 +77,7 @@ public class RecruitController {
       @RequestParam(required = false) String region,
       @RequestParam(required = false) String sports,
       @RequestParam(required = false) Gender gender,
-      @RequestParam(required = false) boolean closeInclude
+      @RequestParam(required = false, defaultValue = "false") boolean closeInclude
       ){
 
     RecruitListDto result =

--- a/src/test/java/com/anonymous/usports/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/member/service/MemberServiceTest.java
@@ -10,6 +10,7 @@ import com.anonymous.usports.domain.member.dto.MailResponse;
 import com.anonymous.usports.domain.member.dto.MemberDto;
 import com.anonymous.usports.domain.member.dto.MemberLogin;
 import com.anonymous.usports.domain.member.dto.MemberRegister;
+import com.anonymous.usports.domain.member.dto.MemberSearchResponse;
 import com.anonymous.usports.domain.member.dto.MemberUpdate;
 import com.anonymous.usports.domain.member.dto.MemberWithdraw;
 import com.anonymous.usports.domain.member.dto.PasswordLostResponse;
@@ -41,6 +42,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -1275,5 +1277,41 @@ public class MemberServiceTest {
             //then
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.MEMBER_ID_UNMATCH);
         }
+    }
+
+    @Test
+    @DisplayName("회원 검색")
+    void searchMember(){
+        //given
+        MemberEntity member1 = member(1L, "test", "테스트1", "joons@gmail.com", "password1",
+            "010-1234-1234", LocalDate.now(), Gender.MALE, null, null, null,
+            true, Role.UNAUTH);
+        MemberEntity member2 = member(2L, "testTwooo", "테스트2", "joons@gmail.com", "password1",
+            "010-1234-1234", LocalDate.now(), Gender.MALE, null, null, null,
+            true, Role.UNAUTH);
+        MemberEntity member3 = member(3L, "test3", "검색테스트3", "joons@gmail.com", "password1",
+            "010-1234-1234", LocalDate.now(), Gender.MALE, null, null, null,
+            true, Role.UNAUTH);
+
+        List<MemberEntity> memberList = new ArrayList<>();
+        memberList.add(member1);
+        memberList.add(member2);
+        memberList.add(member3);
+
+        Collections.sort(memberList, (m1, m2) -> m1.getAccountName().length() - m2.getAccountName().length());
+
+        String search = "test";
+
+        when(memberRepository.findAllByAccountNameContainingOrderByAccountNameAsc(search))
+            .thenReturn(memberList);
+
+        //when
+        List<MemberSearchResponse> responseList = memberService.searchMember(search);
+
+        //then
+        for (MemberSearchResponse memberSearchResponse : responseList) {
+            assertThat(memberSearchResponse.getAccountName()).contains(search);
+        }
+
     }
 }

--- a/src/test/java/com/anonymous/usports/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/anonymous/usports/domain/member/service/MemberServiceTest.java
@@ -1302,7 +1302,7 @@ public class MemberServiceTest {
 
         String search = "test";
 
-        when(memberRepository.findAllByAccountNameContainingOrderByAccountNameAsc(search))
+        when(memberRepository.findAllByAccountNameContaining(search))
             .thenReturn(memberList);
 
         //when


### PR DESCRIPTION
### 변경사항
[ 회원 검색 ]
- accountName을 %LIKE%으로 포함하는 회원을 모두 검색
- accountName의 길이가 작은 순으로 정렬 ( 길이가 가장 작은것이 일치하는 것임 )

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

