### PR TITLE
Refactor: 채팅 내역 페이징 처리 및 기록 섬네일 작업

### DIFF
--- a/src/main/java/com/anonymous/usports/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/anonymous/usports/domain/follow/controller/FollowController.java
@@ -35,12 +35,21 @@ public class FollowController {
   }
 
   @ApiOperation("타입별 팔로우 리스트 가져오기")
-  @GetMapping("/follow/{type}")
+  @GetMapping("/follow/{memberId}/{type}")
   public ResponseEntity<FollowListDto> getFollowList(
+      @PathVariable Long memberId,
       @PathVariable FollowListType type,
+      @RequestParam(value = "page", defaultValue = "1") int page) {
+    FollowListDto followList = followService.getFollowPage(type, page, memberId);
+    return ResponseEntity.ok(followList);
+  }
+
+  @ApiOperation("나에게 팔로우 신청한 리스트 가져오기")
+  @GetMapping("/follow/requested-follow")
+  public ResponseEntity<FollowListDto> getRequestedFollowList(
       @RequestParam(value = "page", defaultValue = "1") int page,
       @AuthenticationPrincipal MemberDto loginMember) {
-    FollowListDto followList = followService.getFollowPage(type, page, loginMember.getMemberId());
+    FollowListDto followList = followService.getRequestedFollowList(page, loginMember.getMemberId());
     return ResponseEntity.ok(followList);
   }
 

--- a/src/main/java/com/anonymous/usports/domain/follow/service/FollowService.java
+++ b/src/main/java/com/anonymous/usports/domain/follow/service/FollowService.java
@@ -9,7 +9,9 @@ public interface FollowService {
 
   FollowResponse changeFollow(Long loginMemberId, Long toMemberId);
 
-  FollowListDto getFollowPage(FollowListType type, int page, Long loginMemberId);
+  FollowListDto getFollowPage(FollowListType type, int page, Long memberId);
+
+  FollowListDto getRequestedFollowList(int page, Long loginMemberId);
 
   FollowResponse manageFollow(Long fromMemberId, Long loginMemberId, FollowDecisionType decision);
 }

--- a/src/main/java/com/anonymous/usports/domain/follow/service/impl/FollowServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/follow/service/impl/FollowServiceImpl.java
@@ -79,23 +79,34 @@ public class FollowServiceImpl implements FollowService {
    * 들어온 FOLLOW 신청 리스트 FOLLOWER: 나를 FOLLOW 하는 리스트
    */
   @Override
-  public FollowListDto getFollowPage(FollowListType type, int page, Long loginMemberId) {
-    MemberEntity loginMember = memberRepository.findById(loginMemberId)
+  public FollowListDto getFollowPage(FollowListType type, int page, Long memberId) {
+    MemberEntity member = memberRepository.findById(memberId)
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
 
     PageRequest pageRequest = PageRequest.of(page - 1, NumberConstant.PAGE_SIZE_DEFAULT);
 
     Page<FollowEntity> findPage;
     if (type == FollowListType.FOLLOWING) {
-      findPage = followRepository.findAllByFromMemberAndFollowStatusOrderByFollowDateDesc(loginMember,
+      findPage = followRepository.findAllByFromMemberAndFollowStatusOrderByFollowDateDesc(member,
           FollowStatus.ACTIVE, pageRequest);
-    } else if (type == FollowListType.REQUESTED_FOLLOW) {
-      findPage = followRepository.findAllByToMemberAndFollowStatus(loginMember, FollowStatus.WAITING,
-          pageRequest);
     } else {
-      findPage = followRepository.findAllByToMemberAndFollowStatusOrderByFollowDateDesc(loginMember,
+      findPage = followRepository.findAllByToMemberAndFollowStatusOrderByFollowDateDesc(member,
           FollowStatus.ACTIVE, pageRequest);
     }
+    return FollowListDto.fromEntityPage(findPage);
+  }
+
+  @Override
+  public FollowListDto getRequestedFollowList(int page, Long loginMemberId) {
+    MemberEntity loginMember = memberRepository.findById(loginMemberId)
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+    PageRequest pageRequest = PageRequest.of(page - 1, NumberConstant.PAGE_SIZE_DEFAULT);
+
+    Page<FollowEntity> findPage =
+        followRepository.findAllByToMemberAndFollowStatus(loginMember, FollowStatus.WAITING,
+        pageRequest);
+
     return FollowListDto.fromEntityPage(findPage);
   }
 

--- a/src/main/java/com/anonymous/usports/domain/record/dto/RecordDto.java
+++ b/src/main/java/com/anonymous/usports/domain/record/dto/RecordDto.java
@@ -42,7 +42,7 @@ public class RecordDto {
 
   private List<String> imageAddressList;
 
-  private List<String> thImageAddressList;
+  private List<String> thumbnailAddressList;
 
   private List<CommentDto> commentList;
 
@@ -62,7 +62,7 @@ public class RecordDto {
         .updatedAt(recordEntity.getUpdatedAt())
         .countComment(recordEntity.getCountComment())
         .imageAddressList(recordEntity.getImageAddress())
-        .thImageAddressList(recordEntity.getThImageAddress())
+        .thumbnailAddressList(recordEntity.getThumbnailAddress())
         .countRecordLike(recordEntity.getCountRecordLikes())
         .build();
   }

--- a/src/main/java/com/anonymous/usports/domain/record/dto/RecordDto.java
+++ b/src/main/java/com/anonymous/usports/domain/record/dto/RecordDto.java
@@ -42,6 +42,8 @@ public class RecordDto {
 
   private List<String> imageAddressList;
 
+  private List<String> thImageAddressList;
+
   private List<CommentDto> commentList;
 
   private Long countRecordLike;
@@ -60,6 +62,7 @@ public class RecordDto {
         .updatedAt(recordEntity.getUpdatedAt())
         .countComment(recordEntity.getCountComment())
         .imageAddressList(recordEntity.getImageAddress())
+        .thImageAddressList(recordEntity.getThImageAddress())
         .countRecordLike(recordEntity.getCountRecordLikes())
         .build();
   }

--- a/src/main/java/com/anonymous/usports/domain/record/dto/RecordRegister.java
+++ b/src/main/java/com/anonymous/usports/domain/record/dto/RecordRegister.java
@@ -24,12 +24,13 @@ public class RecordRegister {
     private String content;
 
     public static RecordEntity toEntity(RecordRegister.Request request, MemberEntity member,
-        SportsEntity sports, List<String> recordImageList) {
+        SportsEntity sports, List<String> recordImageList, List<String> thumbnailImageList) {
       return RecordEntity.builder()
           .member(member)
           .sports(sports)
           .recordContent(request.getContent())
           .imageAddress(recordImageList)
+          .thImageAddress(thumbnailImageList)
           .build();
     }
   }

--- a/src/main/java/com/anonymous/usports/domain/record/dto/RecordRegister.java
+++ b/src/main/java/com/anonymous/usports/domain/record/dto/RecordRegister.java
@@ -30,7 +30,7 @@ public class RecordRegister {
           .sports(sports)
           .recordContent(request.getContent())
           .imageAddress(recordImageList)
-          .thImageAddress(thumbnailImageList)
+          .thumbnailAddress(thumbnailImageList)
           .build();
     }
   }

--- a/src/main/java/com/anonymous/usports/domain/record/entity/RecordEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/record/entity/RecordEntity.java
@@ -77,8 +77,8 @@ public class RecordEntity {
 
   @Convert(converter = StringListConverter.class)
   @Builder.Default
-  @Column(name = "th_image_address", columnDefinition = "TEXT")
-  private List<String> thImageAddress = new ArrayList<>();
+  @Column(name = "thumbnail_image_address", columnDefinition = "TEXT")
+  private List<String> thumbnailAddress = new ArrayList<>();
 
   @Override
   public boolean equals(Object o) {

--- a/src/main/java/com/anonymous/usports/domain/record/entity/RecordEntity.java
+++ b/src/main/java/com/anonymous/usports/domain/record/entity/RecordEntity.java
@@ -75,6 +75,11 @@ public class RecordEntity {
   @Column(name = "image_address", columnDefinition = "TEXT")
   private List<String> imageAddress = new ArrayList<>();
 
+  @Convert(converter = StringListConverter.class)
+  @Builder.Default
+  @Column(name = "th_image_address", columnDefinition = "TEXT")
+  private List<String> thImageAddress = new ArrayList<>();
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/src/main/java/com/anonymous/usports/domain/record/service/impl/RecordServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/record/service/impl/RecordServiceImpl.java
@@ -44,7 +44,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -314,7 +313,7 @@ public class RecordServiceImpl implements RecordService {
           }
           record.getImageAddress().remove(imageUrl); //record의 imageAdress 리스트에서 해당 url 제거
           String thImageUrl = imageUrl.replaceFirst(bucketName, THUMBNAIL_BUCKET_NAME);
-          record.getThImageAddress().remove(thImageUrl);
+          record.getThumbnailAddress().remove(thImageUrl);
           redisTemplate.opsForList().rightPush(URLS_TO_DELETE, imageUrl); //제거한 Url을 redis에 insert
         }
       }

--- a/src/main/java/com/anonymous/usports/domain/record/service/impl/RecordServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/domain/record/service/impl/RecordServiceImpl.java
@@ -414,8 +414,7 @@ public class RecordServiceImpl implements RecordService {
   /**
    * 새벽 3시에 모아놓은 Url에 해당하는 S3 객체들을 제거
    */
-//  @Scheduled(cron = "0 0 3 * * ?")
-  @Scheduled(cron = "0 * * * * ?")
+  @Scheduled(cron = "0 0 3 * * ?")
   public void deleteRedisUrlFromS3() {
     List<String> urlsToDelete = redisTemplate.opsForList().range(URLS_TO_DELETE, 0, -1);
     if (urlsToDelete != null) {

--- a/src/main/java/com/anonymous/usports/global/constant/ChatConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/ChatConstant.java
@@ -22,4 +22,6 @@ public class ChatConstant {
     public static final String ROUTING_KEY = "room.*";
 
     public static final String MARK_READ_CHAT = "읽은 채팅을 체크했습니다.";
+
+    public static final int CHAT_MESSAGE_SIZE = 100;
 }

--- a/src/main/java/com/anonymous/usports/global/type/FollowListType.java
+++ b/src/main/java/com/anonymous/usports/global/type/FollowListType.java
@@ -2,6 +2,5 @@ package com.anonymous.usports.global.type;
 
 public enum FollowListType {
   FOLLOWING,
-  FOLLOWER,
-  REQUESTED_FOLLOW
+  FOLLOWER
 }

--- a/src/main/java/com/anonymous/usports/websocket/controller/ChatPartakeController.java
+++ b/src/main/java/com/anonymous/usports/websocket/controller/ChatPartakeController.java
@@ -17,7 +17,7 @@ public class ChatPartakeController {
   private final ChatPartakeService chatPartakeService;
 
   // 웹 소켓 연결이 끊어질 때 해당 api를 호출해서 마지막 읽은 chatId를 등록한다.
-  @PostMapping("/markChat")
+  @PostMapping("/markchat")
   public ResponseEntity<MarkAsReadRequestDto.Response> markChatAsRead(
       @RequestBody MarkAsReadRequestDto.Request request
   ) {

--- a/src/main/java/com/anonymous/usports/websocket/controller/ChatRoomController.java
+++ b/src/main/java/com/anonymous/usports/websocket/controller/ChatRoomController.java
@@ -1,7 +1,7 @@
 package com.anonymous.usports.websocket.controller;
 
 import com.anonymous.usports.domain.member.dto.MemberDto;
-import com.anonymous.usports.websocket.dto.ChatMessageDto;
+import com.anonymous.usports.websocket.dto.ChatMessageListDto;
 import com.anonymous.usports.websocket.dto.ChatPartakeDto;
 import com.anonymous.usports.websocket.dto.ChatResponses.ChatEnterDto;
 import com.anonymous.usports.websocket.dto.ChatResponses.ChatInviteDto;
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -86,11 +87,12 @@ public class ChatRoomController {
             chatRoomService.exitChat(chatRoomId, memberDto));
     }
 
-  @GetMapping("/{chatRoomId}/getMessagelist")
-  public ResponseEntity<List<ChatMessageDto>> getMessageList(
-      @PathVariable Long chatRoomId,
-      @AuthenticationPrincipal MemberDto memberDto
-  ){
-    return ResponseEntity.ok(chatRoomService.getMessageList(chatRoomId,memberDto));
-  }
+    @GetMapping("/{chatRoomId}/getMessagelist")
+    public ResponseEntity<ChatMessageListDto> getMessageList(
+        @PathVariable Long chatRoomId,
+        @RequestParam(value = "page",defaultValue = "1") int page,
+        @AuthenticationPrincipal MemberDto memberDto
+    ){
+        return ResponseEntity.ok(chatRoomService.getMessageList(chatRoomId,memberDto,page));
+    }
 }

--- a/src/main/java/com/anonymous/usports/websocket/controller/ChatRoomController.java
+++ b/src/main/java/com/anonymous/usports/websocket/controller/ChatRoomController.java
@@ -87,7 +87,7 @@ public class ChatRoomController {
             chatRoomService.exitChat(chatRoomId, memberDto));
     }
 
-    @GetMapping("/{chatRoomId}/getMessagelist")
+    @GetMapping("/{chatRoomId}/message-list")
     public ResponseEntity<ChatMessageListDto> getMessageList(
         @PathVariable Long chatRoomId,
         @RequestParam(value = "page",defaultValue = "1") int page,

--- a/src/main/java/com/anonymous/usports/websocket/dto/ChatMessageListDto.java
+++ b/src/main/java/com/anonymous/usports/websocket/dto/ChatMessageListDto.java
@@ -1,0 +1,52 @@
+package com.anonymous.usports.websocket.dto;
+
+import com.anonymous.usports.domain.member.entity.MemberEntity;
+import com.anonymous.usports.websocket.entity.ChattingEntity;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatMessageListDto {
+
+  private int currentPage;
+  private int currentElements;
+  private int pageSize;
+  private int totalPages;
+  private int totalElements;
+
+  private List<ChatMessageDto> list;
+
+  public ChatMessageListDto(Page<ChattingEntity> chattingEntityPage, MemberEntity member) {
+    this.currentPage = chattingEntityPage.getNumber()+1;
+    this.currentElements = chattingEntityPage.getNumberOfElements();
+    this.pageSize = chattingEntityPage.getSize();
+    this.totalPages = chattingEntityPage.getTotalPages();
+    this.totalElements = (int) chattingEntityPage.getTotalElements();
+    this.list = chattingEntityPage.getContent().stream()
+        .map(chattingEntity -> toChatMessageDto(chattingEntity, member))
+        .collect(Collectors.toList());
+  }
+  private ChatMessageDto toChatMessageDto(ChattingEntity chattingEntity, MemberEntity senderMember) {
+    return ChatMessageDto.builder()
+        .chatRoomId(chattingEntity.getChatRoomId())
+        .userId(chattingEntity.getMemberId())
+        .user(senderMember.getName())
+        .time(chattingEntity.getCreatedAt())
+        .imageAddress(senderMember.getProfileImage())
+        .content(chattingEntity.getContent())
+        .type(chattingEntity.getType())
+        .build();
+  }
+
+
+}

--- a/src/main/java/com/anonymous/usports/websocket/repository/ChattingRepository.java
+++ b/src/main/java/com/anonymous/usports/websocket/repository/ChattingRepository.java
@@ -1,18 +1,20 @@
 package com.anonymous.usports.websocket.repository;
 
 import com.anonymous.usports.websocket.entity.ChattingEntity;
-import java.util.List;
 import org.bson.types.ObjectId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChattingRepository extends MongoRepository<ChattingEntity, String> {
-  List<ChattingEntity> findAllByChatRoomId(Long chatRoomId);
+
+  Page<ChattingEntity> findAllByChatRoomId(Long chatRoomId, Pageable pageable);
 
   ChattingEntity findTopByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId);
 
-//  @Query("{ 'chatRoomId' : ?0, '_id' : { $gt : { '$oid': ?1 } } }") String을 사용할 경우 이 쿼리가 필요함. String을 objectId로 변환
+  //  @Query("{ 'chatRoomId' : ?0, '_id' : { $gt : { '$oid': ?1 } } }") String을 사용할 경우 이 쿼리가 필요함. String을 objectId로 변환
   long countAllByChatRoomIdAndIdGreaterThan(Long chatRoomId, ObjectId lastReadChatId);
 
 }

--- a/src/main/java/com/anonymous/usports/websocket/service/ChatRoomService.java
+++ b/src/main/java/com/anonymous/usports/websocket/service/ChatRoomService.java
@@ -1,7 +1,7 @@
 package com.anonymous.usports.websocket.service;
 
 import com.anonymous.usports.domain.member.dto.MemberDto;
-import com.anonymous.usports.websocket.dto.ChatMessageDto;
+import com.anonymous.usports.websocket.dto.ChatMessageListDto;
 import com.anonymous.usports.websocket.dto.ChatPartakeDto;
 import com.anonymous.usports.websocket.dto.ChatResponses.ChatEnterDto;
 import com.anonymous.usports.websocket.dto.ChatResponses.ChatInviteDto;
@@ -28,5 +28,5 @@ public interface ChatRoomService {
     String exitChat(Long chatRoomId, MemberDto memberDto);
 
   // 채팅방에서 채팅 내역 가져오기
-  List<ChatMessageDto> getMessageList(Long chatRoomId, MemberDto memberDto);
+  ChatMessageListDto getMessageList(Long chatRoomId, MemberDto memberDto, int page);
 }

--- a/src/test/java/com/anonymous/usports/domain/follow/service/impl/FollowServiceImplTest.java
+++ b/src/test/java/com/anonymous/usports/domain/follow/service/impl/FollowServiceImplTest.java
@@ -92,7 +92,8 @@ class FollowServiceImplTest {
           .thenReturn(Optional.of(fromMember));
       when(memberRepository.findById(2L))
           .thenReturn(Optional.of(toMember));
-      when(followRepository.findByFromMemberAndToMember(fromMember, toMember)).thenReturn(Optional.empty());
+      when(followRepository.findByFromMemberAndToMember(fromMember, toMember))
+          .thenReturn(Optional.empty());
 
       FollowResponse response = followService.changeFollow(fromMember.getMemberId(),
           toMember.getMemberId());
@@ -114,7 +115,8 @@ class FollowServiceImplTest {
           .thenReturn(Optional.of(fromMember));
       when(memberRepository.findById(2L))
           .thenReturn(Optional.of(toMember));
-      when(followRepository.findByFromMemberAndToMember(fromMember, toMember)).thenReturn(Optional.of(follow));
+      when(followRepository.findByFromMemberAndToMember(fromMember, toMember))
+          .thenReturn(Optional.of(follow));
 
       FollowResponse response = followService.changeFollow(fromMember.getMemberId(),
           toMember.getMemberId());
@@ -138,7 +140,8 @@ class FollowServiceImplTest {
           .thenReturn(Optional.of(fromMember));
       when(memberRepository.findById(2L))
           .thenReturn(Optional.of(toMember));
-      when(followRepository.findByFromMemberAndToMember(fromMember, toMember)).thenReturn(Optional.of(follow));
+      when(followRepository.findByFromMemberAndToMember(fromMember, toMember))
+          .thenReturn(Optional.of(follow));
 
       FollowResponse response = followService.changeFollow(fromMember.getMemberId(),
           toMember.getMemberId());
@@ -189,7 +192,7 @@ class FollowServiceImplTest {
     @Test
     @DisplayName("성공 - FOLLOWING 리스트 가져오기")
     void success_GetFollowingPage() {
-      MemberEntity loginMember = createMember(1L);
+      MemberEntity member = createMember(1L);
       List<MemberEntity> members = new ArrayList<>();
 
       Long numberOfMembers = 15L;
@@ -201,7 +204,7 @@ class FollowServiceImplTest {
       List<FollowEntity> followEntities = new ArrayList<>();
 
       for (Long i = 2L; i <= numberOfMembers + 1; i++) {
-        followEntities.add(createFollow(i * 100, loginMember, createMember(i)));
+        followEntities.add(createFollow(i * 100, member, createMember(i)));
       }
 
       int page = 2;
@@ -209,13 +212,13 @@ class FollowServiceImplTest {
       int start = (int) pageRequest.getOffset();
       int end = Math.min((start + pageRequest.getPageSize()), followEntities.size());
       List<FollowEntity> paginatedFollowEntities = followEntities.subList(start, end);
-      when(memberRepository.findById(1L)).thenReturn(Optional.of(loginMember));
-      when(followRepository.findAllByFromMemberAndFollowStatusOrderByFollowDateDesc(loginMember,
+      when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+      when(followRepository.findAllByFromMemberAndFollowStatusOrderByFollowDateDesc(member,
           FollowStatus.ACTIVE, pageRequest))
           .thenReturn(new PageImpl<>(paginatedFollowEntities, pageRequest, followEntities.size()));
 
-      FollowListDto result = followService.getFollowPage(FollowListType.FOLLOWING, page,
-          loginMember.getMemberId());
+      FollowListDto result =
+          followService.getFollowPage(FollowListType.FOLLOWING, page, member.getMemberId());
 
       assertNotNull(result);
       assertEquals(followEntities.size(), result.getTotalElements());
@@ -231,7 +234,7 @@ class FollowServiceImplTest {
     @Test
     @DisplayName("성공 - FOLLOWER 리스트 가져오기")
     void success_GetFollowerPage() {
-      MemberEntity loginMember = createMember(1L);
+      MemberEntity member = createMember(1L);
       List<MemberEntity> members = new ArrayList<>();
 
       Long numberOfMembers = 15L;
@@ -243,7 +246,7 @@ class FollowServiceImplTest {
       List<FollowEntity> followEntities = new ArrayList<>();
 
       for (Long i = 2L; i <= numberOfMembers + 1; i++) {
-        followEntities.add(createFollow(i * 100, createMember(i), loginMember));
+        followEntities.add(createFollow(i * 100, createMember(i), member));
       }
 
       int page = 1;
@@ -251,13 +254,14 @@ class FollowServiceImplTest {
       int start = (int) pageRequest.getOffset();
       int end = Math.min((start + pageRequest.getPageSize()), followEntities.size());
       List<FollowEntity> paginatedFollowEntities = followEntities.subList(start, end);
-      when(memberRepository.findById(1L)).thenReturn(Optional.of(loginMember));
-      when(followRepository.findAllByToMemberAndFollowStatusOrderByFollowDateDesc(loginMember,
-          FollowStatus.ACTIVE, pageRequest))
+
+      when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+      when(followRepository.findAllByToMemberAndFollowStatusOrderByFollowDateDesc
+          (member, FollowStatus.ACTIVE, pageRequest))
           .thenReturn(new PageImpl<>(paginatedFollowEntities, pageRequest, followEntities.size()));
 
-      FollowListDto result = followService.getFollowPage(FollowListType.FOLLOWER, page,
-          loginMember.getMemberId());
+      FollowListDto result =
+          followService.getFollowPage(FollowListType.FOLLOWER, page, member.getMemberId());
 
       assertNotNull(result);
       assertEquals(followEntities.size(), result.getTotalElements());
@@ -271,8 +275,49 @@ class FollowServiceImplTest {
     }
 
     @Test
-    @DisplayName("성공 - REQUESTED_FOLLOW 리스트 가져오기")
-    void success_GetRequestedFolloWPage() {
+    @DisplayName("실패 - MEMBER_NOT_FOUND")
+    void fail_MemberNotFound() {
+      MemberEntity member = createMember(1L);
+      List<MemberEntity> members = new ArrayList<>();
+
+      Long numberOfMembers = 15L;
+
+      for (Long i = 2L; i <= numberOfMembers + 1; i++) {
+        members.add(createMember(i));
+      }
+
+      List<FollowEntity> followEntities = new ArrayList<>();
+
+      for (Long i = 2L; i <= numberOfMembers + 1; i++) {
+        followEntities.add(createFollow(i * 100, member, createMember(i)));
+      }
+
+      int page = 2;
+      PageRequest pageRequest = PageRequest.of(page - 1, NumberConstant.PAGE_SIZE_DEFAULT);
+      int start = (int) pageRequest.getOffset();
+      int end = Math.min((start + pageRequest.getPageSize()), followEntities.size());
+      List<FollowEntity> paginatedFollowEntities = followEntities.subList(start, end);
+
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.empty());
+
+      MemberException exception =
+          catchThrowableOfType(() ->
+                  followService.getFollowPage(FollowListType.FOLLOWING, page,
+                      member.getMemberId()),
+              MemberException.class);
+      assertEquals(exception.getErrorCode(), ErrorCode.MEMBER_NOT_FOUND);
+
+    }
+  }
+
+  @Nested
+  @DisplayName("Follow 신청 받은 리스트")
+  class RequestesFollowList {
+
+    @Test
+    @DisplayName("성공 - Follow 신청 받은 리스트")
+    void success_RequestedFollowList() {
       MemberEntity loginMember = createMember(1L);
       loginMember.setProfileOpen(false);
       List<MemberEntity> members = new ArrayList<>();
@@ -303,8 +348,7 @@ class FollowServiceImplTest {
           pageRequest))
           .thenReturn(new PageImpl<>(paginatedFollowEntities, pageRequest, followEntities.size()));
 
-      FollowListDto result = followService.getFollowPage(
-          FollowListType.REQUESTED_FOLLOW, page, loginMember.getMemberId());
+      FollowListDto result = followService.getRequestedFollowList(page, loginMember.getMemberId());
 
       assertNotNull(result);
       assertEquals(followEntities.size(), result.getTotalElements());
@@ -321,13 +365,37 @@ class FollowServiceImplTest {
     @DisplayName("실패 - MEMBER_NOT_FOUND")
     void fail_MemberNotFound() {
       MemberEntity loginMember = createMember(1L);
+      loginMember.setProfileOpen(false);
+      List<MemberEntity> members = new ArrayList<>();
+
+      Long numberOfMembers = 15L;
+
+      for (Long i = 2L; i <= numberOfMembers + 1; i++) {
+        members.add(createMember(i));
+      }
+
+      List<FollowEntity> followEntities = new ArrayList<>();
+
+      for (Long i = 2L; i <= numberOfMembers + 1; i++) {
+        FollowEntity follow = createFollow(i * 100, createMember(i), loginMember);
+        follow.setFollowStatus(FollowStatus.WAITING);
+        followEntities.add(follow);
+      }
+
+      int page = 1;
+      PageRequest pageRequest = PageRequest.of(page - 1, NumberConstant.PAGE_SIZE_DEFAULT);
+      int start = (int) pageRequest.getOffset();
+      int end = Math.min((start + pageRequest.getPageSize()), followEntities.size());
+
+      List<FollowEntity> paginatedFollowEntities = followEntities.subList(start, end);
+
 
       when(memberRepository.findById(1L))
           .thenReturn(Optional.empty());
 
       MemberException exception =
           catchThrowableOfType(() ->
-                  followService.changeFollow(loginMember.getMemberId(), loginMember.getMemberId()),
+                  followService.getRequestedFollowList(page, loginMember.getMemberId()),
               MemberException.class);
       assertEquals(exception.getErrorCode(), ErrorCode.MEMBER_NOT_FOUND);
 


### PR DESCRIPTION
# 변경사항

## AS-IS

### [채팅 내역 페이징 처리]

기존 List<ChatMessageDto>로 불러오던 채팅 내역을 100개씩 페이징 처리하여 불러오도록 수정했습니다.

### [기록글 섬네일 정보 DB 저장]

AWS Lambda를 이용해서 사진이 버킷에 업로드 될 때 섬네일 전용 버킷에 이미지가 리사이징 되어 저장됩니다.
(Lambda를 사용했기 때문에 코드 상에서 리사이징 하는 부분은 없습니다.)

따라서 DB에 섬네일 URL을 저장 할 필요성이 생겼습니다. 

섬네일 관련 thImageAddress 항목이 엔티티에 추가되었고, Dto에도 thImageAddressList 항목이 추가되었습니다.

원본 이미지 URL을  DB에 저장 시 섬네일 URL도 같이 저장됩니다.

기록글 수정 시 이미지에 수정이 발생하면 섬네일URL도 수정하는 부분이 추가되었습니다.
 
### [FollowList 방식 변경]

기존 FollowList는 한 개의 API에서 FollowType 별로 Following, Follower, RequestedFollow 3개의 타입으로 list를 받아오는 방식이였습니다.

해당 회원 본인이 아닌 다른 회원도 그 회원이 누구를 팔로우 하는지 볼 수 있어야 한다는 의견이 있었기에 회원 당사자가 아니더라도 누구를 팔로우하고 누가 그 회원을 팔로우 하는지 리스트를 볼 수 있도록 변경되었습니다.

해당 회원에게 온 팔로우 신청은 아예 getRequestedFollowList 라는 별도 API로 구현하였습니다.

이러한 변화에 따라 FollowType도 Follower와 Following, 2개로 변경되었습니다.

기존 테스트 코드를 수정했고 getRequestedFollowList 에 대한 테스트 코드가 추가되었습니다.

### [API URL 변경]

markChatAsRead API와 getMessageList API의 URL 이 적절하지 않은 것 같아 수정하였습니다.



## TO-BE

# 테스트

- [ ] 테스트 코드
- [x] API 테스트 

