### PR TITLE
Refactor: ChatPartake Swagger 추가 및 주석 추가

### DIFF
--- a/src/main/java/com/anonymous/usports/websocket/controller/ChatPartakeController.java
+++ b/src/main/java/com/anonymous/usports/websocket/controller/ChatPartakeController.java
@@ -2,6 +2,8 @@ package com.anonymous.usports.websocket.controller;
 
 import com.anonymous.usports.websocket.dto.MarkAsReadRequestDto;
 import com.anonymous.usports.websocket.service.ChatPartakeService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Api(tags = "채팅 참여(ChatPartake)")
 @RestController
 @RequiredArgsConstructor
 @Slf4j
@@ -17,6 +20,7 @@ public class ChatPartakeController {
   private final ChatPartakeService chatPartakeService;
 
   // 웹 소켓 연결이 끊어질 때 해당 api를 호출해서 마지막 읽은 chatId를 등록한다.
+  @ApiOperation("마지막 채팅 ID 체크 후 DB 저장")
   @PostMapping("/markchat")
   public ResponseEntity<MarkAsReadRequestDto.Response> markChatAsRead(
       @RequestBody MarkAsReadRequestDto.Request request

--- a/src/main/java/com/anonymous/usports/websocket/service/impl/ChatPartakeServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/websocket/service/impl/ChatPartakeServiceImpl.java
@@ -41,6 +41,7 @@ public class ChatPartakeServiceImpl implements ChatPartakeService {
     ChatPartakeEntity chatPartake = chatPartakeRepository.findByChatRoomEntityAndMemberEntity(chatRoom, member)
         .orElseThrow(() -> new ChatException(ErrorCode.USER_NOT_IN_THE_CHAT));
 
+    // 해당 채팅방 가장 최근 ChattingEntity 가져오기
     ChattingEntity chattingEntity = chattingRepository.findTopByChatRoomIdOrderByCreatedAtDesc(chatRoomId);
 
     chatPartake.setLastReadChatId(chattingEntity.getId().toString());


### PR DESCRIPTION
### 변경사항

**AS-IS**

[ChatPartakeController를 Swagger 어노테이션 추가]

ChatPartakeController 에 있는 markChatAsRead 에 ApiOperation 어노테이션 추가했습니다.

[ChatPartakeServiceImpl에 주석 추가]

markChatAsRead 메서드를 설명하는 주석을 추가했습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 

