### PR TITLE
Refactor: MessageList 관련 코드 수정

### DIFF
--- a/src/main/java/com/anonymous/usports/websocket/dto/ChatMessageListDto.java
+++ b/src/main/java/com/anonymous/usports/websocket/dto/ChatMessageListDto.java
@@ -26,27 +26,35 @@ public class ChatMessageListDto {
 
   private List<ChatMessageDto> list;
 
-  public ChatMessageListDto(Page<ChattingEntity> chattingEntityPage, MemberEntity member) {
+  public ChatMessageListDto(Page<ChattingEntity> chattingEntityPage , List<MemberEntity> participantList) {
     this.currentPage = chattingEntityPage.getNumber()+1;
     this.currentElements = chattingEntityPage.getNumberOfElements();
     this.pageSize = chattingEntityPage.getSize();
     this.totalPages = chattingEntityPage.getTotalPages();
     this.totalElements = (int) chattingEntityPage.getTotalElements();
     this.list = chattingEntityPage.getContent().stream()
-        .map(chattingEntity -> toChatMessageDto(chattingEntity, member))
+        .map(chattingEntity -> toChatMessageDto(chattingEntity,participantList))
         .collect(Collectors.toList());
   }
-  private ChatMessageDto toChatMessageDto(ChattingEntity chattingEntity, MemberEntity senderMember) {
+
+  public ChatMessageDto toChatMessageDto(ChattingEntity chattingEntity, List<MemberEntity> participantList) {
+    MemberEntity member = findMemberById(chattingEntity.getMemberId(), participantList);
+
     return ChatMessageDto.builder()
         .chatRoomId(chattingEntity.getChatRoomId())
-        .userId(chattingEntity.getMemberId())
-        .user(senderMember.getName())
+        .userId(member.getMemberId())
+        .user(member.getAccountName())
         .time(chattingEntity.getCreatedAt())
-        .imageAddress(senderMember.getProfileImage())
+        .imageAddress(member.getProfileImage())
         .content(chattingEntity.getContent())
         .type(chattingEntity.getType())
         .build();
   }
-
+  private MemberEntity findMemberById(Long memberId, List<MemberEntity> participantList) {
+    return participantList.stream()
+        .filter(member -> memberId.equals(member.getMemberId()))
+        .findFirst()
+        .orElse(null);
+  }
 
 }

--- a/src/main/java/com/anonymous/usports/websocket/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/websocket/service/impl/ChatRoomServiceImpl.java
@@ -365,6 +365,10 @@ public class ChatRoomServiceImpl implements ChatRoomService {
      .orElseThrow(()->new ChatException(ErrorCode.USER_NOT_IN_THE_CHAT));
      */
     Page<ChattingEntity> chatsPage = chattingRepository.findAllByChatRoomId(chatRoomId, pageable);
-    return new ChatMessageListDto(chatsPage, member);
+    List<ChatPartakeEntity> chatPartakeEntities = chatPartakeRepository.findAllByChatRoomEntity(chatRoom);
+    List<MemberEntity> participantList = chatPartakeEntities.stream()
+        .map(ChatPartakeEntity::getMemberEntity)
+        .collect(Collectors.toList());
+    return new ChatMessageListDto(chatsPage, participantList);
   }
 }


### PR DESCRIPTION
### 변경사항

**AS-IS**

[messagelist 관련 코드 수정]

기존에는 senderMember에 채팅 보낸 회원이 아닌 접속한 회원을 넣는 실수를 했기에 코드를 수정합니다.
채팅방에 참여한 MemberEntity의 List를 가져와서 회원ID가 동일한 MemberEntity의 정보를 사용합니다.

**TO-BE**

### 테스트

- [ ] 테스트 코드
- [x] API 테스트 

