### PR TITLE
Feat: 초대 가능한 리스트 추가

### DIFF
--- a/src/main/java/com/anonymous/usports/global/constant/ChatConstant.java
+++ b/src/main/java/com/anonymous/usports/global/constant/ChatConstant.java
@@ -23,5 +23,7 @@ public class ChatConstant {
 
     public static final String MARK_READ_CHAT = "읽은 채팅을 체크했습니다.";
 
+    public static final String NO_CHAT_AVAILABLE = "체크할 채팅이 없습니다.";
+
     public static final int CHAT_MESSAGE_SIZE = 100;
 }

--- a/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
+++ b/src/main/java/com/anonymous/usports/global/exception/ErrorCode.java
@@ -75,6 +75,7 @@ public enum ErrorCode {
   MEMBER_ALREADY_IN_CHAT_ROOM(HttpStatus.BAD_REQUEST, "이미 유저가 채팅방에 있습니다"),
   USER_NOT_IN_THE_CHAT(HttpStatus.NOT_FOUND, "해당 유저는 채팅에 없습니다"),
   CANNOT_CREATE_CHAT_WITH_SAME_USER(HttpStatus.BAD_REQUEST, "내 자신과는 chat을 만들 수 없습니다"),
+  NO_AVAILABLE_LIST(HttpStatus.BAD_REQUEST,"DM 에서는 불러올 수 없는 list 입니다."),
 
   //Type
   TYPE_INVALID_ERROR(HttpStatus.BAD_REQUEST, "Type(enum)이 잘못되었습니다."),

--- a/src/main/java/com/anonymous/usports/websocket/controller/ChatRoomController.java
+++ b/src/main/java/com/anonymous/usports/websocket/controller/ChatRoomController.java
@@ -95,4 +95,12 @@ public class ChatRoomController {
     ){
         return ResponseEntity.ok(chatRoomService.getMessageList(chatRoomId,memberDto,page));
     }
+
+    @GetMapping("/{chatRoomId}/invite-list")
+    public ResponseEntity<List<MemberDto>> getListToInvite(
+        @PathVariable Long chatRoomId,
+        @AuthenticationPrincipal MemberDto memberDto
+    ) {
+        return ResponseEntity.ok(chatRoomService.getListToInvite(chatRoomId, memberDto));
+    }
 }

--- a/src/main/java/com/anonymous/usports/websocket/dto/ChatResponses/ChatEnterDto.java
+++ b/src/main/java/com/anonymous/usports/websocket/dto/ChatResponses/ChatEnterDto.java
@@ -18,6 +18,7 @@ public class ChatEnterDto {
   public static class Response {
     private Long chatRoomId;
     private String chatRoomName;
+    private Long recruitId;
     private List<MemberDto> members;
   }
 

--- a/src/main/java/com/anonymous/usports/websocket/service/ChatRoomService.java
+++ b/src/main/java/com/anonymous/usports/websocket/service/ChatRoomService.java
@@ -29,4 +29,7 @@ public interface ChatRoomService {
 
   // 채팅방에서 채팅 내역 가져오기
   ChatMessageListDto getMessageList(Long chatRoomId, MemberDto memberDto, int page);
+
+  // 초대 가능 리스트(모임 수락 상태이면서 채팅방에 없는 사람) 출력
+  List<MemberDto> getListToInvite(Long chatRoomId, MemberDto memberDto);
 }

--- a/src/main/java/com/anonymous/usports/websocket/service/impl/ChatPartakeServiceImpl.java
+++ b/src/main/java/com/anonymous/usports/websocket/service/impl/ChatPartakeServiceImpl.java
@@ -44,9 +44,17 @@ public class ChatPartakeServiceImpl implements ChatPartakeService {
     // 해당 채팅방 가장 최근 ChattingEntity 가져오기
     ChattingEntity chattingEntity = chattingRepository.findTopByChatRoomIdOrderByCreatedAtDesc(chatRoomId);
 
-    chatPartake.setLastReadChatId(chattingEntity.getId().toString());
-
-    chatPartakeRepository.save(chatPartake);
+    if (chattingEntity != null) {
+      chatPartake.setLastReadChatId(chattingEntity.getId().toString());
+      chatPartakeRepository.save(chatPartake);
+    } else {
+//      chatPartake.setLastReadChatId(null);
+//      chatPartakeRepository.save(chatPartake);
+      //초기값이 null이고 채팅 삭제 기능이 없기 때문에 채팅이 없었다면 어차피 null이라 해당 부분 필요 없음
+      return MarkAsReadRequestDto.Response.builder()
+          .message(ChatConstant.NO_CHAT_AVAILABLE)
+          .build();
+    }
 
     return MarkAsReadRequestDto.Response.builder()
         .message(ChatConstant.MARK_READ_CHAT)

--- a/src/test/java/com/anonymous/usports/domain/record/service/impl/RecordServiceImplTest.java
+++ b/src/test/java/com/anonymous/usports/domain/record/service/impl/RecordServiceImplTest.java
@@ -320,7 +320,7 @@ class RecordServiceImplTest {
       }
       int page = 1;
       PageRequest pageRequest = PageRequest.of(page - 1, NumberConstant.PAGE_SIZE_SIX,
-          Sort.by(Direction.DESC, "updatedAt"));
+          Sort.by(Direction.DESC, "registeredAt"));
       int start = (int) pageRequest.getOffset();
       int end = Math.min((start + pageRequest.getPageSize()), recordEntityList.size());
       List<RecordEntity> paginatedRecordEntities = recordEntityList.subList(start,end);
@@ -360,7 +360,7 @@ class RecordServiceImplTest {
       recordEntityList.add(record2);
       int page = 1;
       PageRequest pageRequest = PageRequest.of(page - 1, NumberConstant.PAGE_SIZE_SIX,
-          Sort.by(Direction.DESC, "updatedAt"));
+          Sort.by(Direction.DESC, "registeredAt"));
       int start = (int) pageRequest.getOffset();
       int end = Math.min((start + pageRequest.getPageSize()), recordEntityList.size());
       List<RecordEntity> paginatedRecordEntities = recordEntityList.subList(start,end);


### PR DESCRIPTION
# 변경사항

## AS-IS

### [초대 가능한 리스트 불러오는 API 추가]

recruit에서 참여자의 상태가 ACCEPTED이면서 채팅방에 참여하지 않은 사람들의 리스트를 출력합니다.

### [markChatAsRead에서 채팅 내역이 없을 때 처리 추가]

기존에는 가져올 ChattingEntity가 없을 경우 해당 부분(chattingEntity.getId().toString())에서 문제가 발생했으나 chattingEntity 존재 여부에 대한 조건을 걸고 없을 시 채팅 내역이 없다는 message를 리턴하도록 수정했습니다.

### [enterChatRoom에서 recruitId도 리턴 값에 포함]

프론트의 요청으로 enterChatRoom에서 recruitId도 리턴 값에 포함되었습니다. 따라서 ChatEnterDto에도 recruitId가 추가되었습니다.

### [getRecordPages의 test 부분 수정]

기존에 getRecordPages에서 정렬 방식으로 UpdatedAt에서 registerdAt으로 변경했으나 미처 테스트 코드를 수정하지 못해 이 부분에서 테스트를 통과하지 못했습니다.
따라서 테스트 코드에서도 해당 부분을 변경하여 테스트를 통과함을 확인했습니다.


## TO-BE

# 테스트

- [ ] 테스트 코드
- [x] API 테스트 

